### PR TITLE
Hide Publicize-items

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dotnet add package Krafs.Publicizer
 Or add directly to your project file:
 ```xml
 <ItemGroup>
-    <PackageReference Include="Krafs.Publicizer" Version="1.0.1" />
+    <PackageReference Include="Krafs.Publicizer" Version="1.0.2" />
 </ItemGroup>
 ```
 
@@ -59,8 +59,8 @@ PackageReferences, like other kinds of References, point towards one or more und
 Below is an example of publicizing two assemblies from the package [Krafs.Rimworld.Ref](https://www.nuget.org/packages/Krafs.Rimworld.Ref/):
 ```xml
 <ItemGroup>
-    <PackageReference Include="Krafs.Publicizer" Version="1.0.1" />
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.3117" />
+    <PackageReference Include="Krafs.Publicizer" Version="1.0.2" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.3200" />
 </ItemGroup>
 
 <ItemGroup>

--- a/src/Publicizer.Tests/Publicizer.Tests.csproj
+++ b/src/Publicizer.Tests/Publicizer.Tests.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="MSBuild.ProjectCreation" Version="6.3.3" />
 	</ItemGroup>
 

--- a/src/Publicizer/Krafs.Publicizer.props
+++ b/src/Publicizer/Krafs.Publicizer.props
@@ -1,5 +1,12 @@
 <Project>
+	
 	<UsingTask
 		TaskName="PublicizeAssemblies"
 		AssemblyFile="$([MSBuild]::ValueOrDefault('$(PublicizeAssembliesTaskAssembly)', '$(MSBuildThisFileDirectory)net472\Publicizer.dll'))" />
+
+	<ItemDefinitionGroup>
+		<Publicize Visible="false" />
+		<DoNotPublicize Visible="false" />
+	</ItemDefinitionGroup>
+	
 </Project>

--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -20,12 +20,12 @@
 		<RepositoryUrl>https://github.com/krafs/Publicizer.git</RepositoryUrl>
 		<Description>MSBuild library for allowing direct access to non-public members in .NET assemblies.</Description>
 		<PackageTags>msbuild accesschecks public publicizer</PackageTags>
-		<Version>1.0.1</Version>
+		<Version>1.0.2</Version>
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="dnlib" Version="3.3.5" />
-		<PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.17.1" PrivateAssets="All" />
+		<PackageReference Include="dnlib" Version="3.4.0" />
+		<PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.18" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="all" ExcludeAssets="runtime" />
 	</ItemGroup>	
 	


### PR DESCRIPTION
Fixes the issue in e.g. Rider where Publicize-items appear as broken files in the project tree.