### PR TITLE
Fix: Console apps can't find publicized dependencies

### DIFF
--- a/src/Publicizer.Tests/PublicizerTests.cs
+++ b/src/Publicizer.Tests/PublicizerTests.cs
@@ -74,7 +74,7 @@ namespace Publicizer.Tests
             Nuget.CreateConfigThatRestoresPublicizerLocally(appRoot);
 
             Process buildAppProcess = Runner.Run("dotnet", "build", appCsprojPath);
-            Process runAppProcess = Runner.Run("mono", appPath);
+            Process runAppProcess = Runner.Run("dotnet", appPath);
 
             Assert.That(buildAppProcess.ExitCode, Is.Zero, buildAppProcess.StandardOutput.ReadToEnd);
             Assert.That(runAppProcess.ExitCode, Is.Zero, runAppProcess.StandardOutput.ReadToEnd);

--- a/src/Publicizer/Krafs.Publicizer.targets
+++ b/src/Publicizer/Krafs.Publicizer.targets
@@ -41,7 +41,7 @@
 				
 		<ItemGroup Condition="$(_useIactStrategy)" >
 			<AssemblyAttribute Include="System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute">
-				<_Parameter1>%(_ReferencePathsToAdd.OriginalFilename)</_Parameter1>
+				<_Parameter1>%(_ReferencePathsToAdd.Filename)</_Parameter1>
 			</AssemblyAttribute>
 		</ItemGroup>
 		

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -120,8 +120,9 @@ namespace Publicizer
 
                 string hash = ComputeHash(assemblyPath, assemblyPublicizes, assemblyDoNotPublicizes);
 
-                string publicizedAssemblyName = $"{assemblyName}.{hash}";
-                string outputAssemblyPath = Path.Combine(OutputDirectory, publicizedAssemblyName + ".dll");
+                string outputAssemblyFolder = Path.Combine(OutputDirectory, $"{assemblyName}.{hash}");
+                Directory.CreateDirectory(outputAssemblyFolder);
+                string outputAssemblyPath = Path.Combine(outputAssemblyFolder, assemblyName + ".dll");
                 if (!File.Exists(outputAssemblyPath))
                 {
                     using ModuleDef module = ModuleDefMD.Load(assemblyPath);
@@ -134,7 +135,6 @@ namespace Publicizer
                 referencePathsToDelete.Add(reference);
                 ITaskItem newReference = new TaskItem(outputAssemblyPath);
                 reference.CopyMetadataTo(newReference);
-                newReference.SetMetadata("OriginalFilename", assemblyName);
                 referencePathsToAdd.Add(newReference);
 
                 string assemblyDirectory = Path.GetDirectoryName(assemblyPath);
@@ -142,7 +142,7 @@ namespace Publicizer
 
                 if (File.Exists(originalDocumentationFullPath))
                 {
-                    string newDocumentationRelativePath = Path.Combine(OutputDirectory, publicizedAssemblyName + ".xml");
+                    string newDocumentationRelativePath = Path.Combine(outputAssemblyFolder, assemblyName + ".xml");
                     string newDocumentationFullPath = Path.GetFullPath(newDocumentationRelativePath);
                     File.Copy(originalDocumentationFullPath, newDocumentationFullPath, overwrite: true);
                 }


### PR DESCRIPTION
When compiling a console application for windows, a <App>.deps.json is created, specifying the names of all the dependencies for the app. For console apps using Publicizer, it used to contain the names of the publicized, cached assemblies instead of the originals. Looking the names up at runtime failed to find the assemblies, because at runtime it should be using the originals.

This fix changes how the cached assemblies are structured. The hash that up until now has been stored in the name of the assembly, is now in the name of the parent folder of the assembly, leaving the name of the assembly intact.