### PR TITLE
Remove option to publicize as reference assembly

### DIFF
--- a/src/Publicizer/AssemblyEditor.cs
+++ b/src/Publicizer/AssemblyEditor.cs
@@ -22,39 +22,28 @@ internal static class AssemblyEditor
         }
     }
 
-    internal static void PublicizeProperty(PropertyDef property, bool publicizeAsReferenceAssemblies)
+    internal static void PublicizeProperty(PropertyDef property)
     {
         if (property.GetMethod is MethodDef getMethod)
         {
-            PublicizeMethod(getMethod, publicizeAsReferenceAssemblies);
+            PublicizeMethod(getMethod);
         }
 
         if (property.SetMethod is MethodDef setMethod)
         {
-            PublicizeMethod(setMethod, publicizeAsReferenceAssemblies);
+            PublicizeMethod(setMethod);
         }
     }
 
-    internal static void PublicizeMethod(MethodDef method, bool publicizeAsReferenceAssemblies)
+    internal static void PublicizeMethod(MethodDef method)
     {
         method.Attributes &= ~MethodAttributes.MemberAccessMask;
         method.Attributes |= MethodAttributes.Public;
-
-        if (publicizeAsReferenceAssemblies)
-        {
-            StripMethodBody(method);
-        }
     }
 
     internal static void PublicizeField(FieldDef field)
     {
         field.Attributes &= ~FieldAttributes.FieldAccessMask;
         field.Attributes |= FieldAttributes.Public;
-    }
-
-    internal static void StripMethodBody(MethodDef method)
-    {
-        method.Body = new CilBody();
-        method.Body.Instructions.Add(new Instruction(OpCodes.Ret));
     }
 }

--- a/src/Publicizer/Krafs.Publicizer.targets
+++ b/src/Publicizer/Krafs.Publicizer.targets
@@ -6,16 +6,11 @@
       <Publicize Include="@(ReferencePath->'%(Filename)')" />
     </ItemGroup>
 
-    <PropertyGroup Condition="$(PublicizeAsReferenceAssemblies) != 'false'">
-      <PublicizeAsReferenceAssemblies>true</PublicizeAsReferenceAssemblies>
-    </PropertyGroup>
-
     <PublicizeAssemblies
       ReferencePaths="@(ReferencePath)"
       Publicizes="@(Publicize)"
       DoNotPublicizes="@(DoNotPublicize)"
-      OutputDirectory="$(IntermediateOutputPath)PublicizedAssemblies\"
-      PublicizeAsReferenceAssemblies="$(PublicizeAsReferenceAssemblies)">
+      OutputDirectory="$(IntermediateOutputPath)PublicizedAssemblies\">
       <Output TaskParameter="ReferencePathsToDelete" ItemName="_ReferencePathsToDelete" />
       <Output TaskParameter="ReferencePathsToAdd" ItemName="_ReferencePathsToAdd" />
     </PublicizeAssemblies>

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -15,7 +15,6 @@ public class PublicizeAssemblies : Task
     public ITaskItem[]? Publicizes { get; set; }
     public ITaskItem[]? DoNotPublicizes { get; set; }
     public string? OutputDirectory { get; set; }
-    public string? PublicizeAsReferenceAssemblies { get; set; }
 
     [Output]
     public ITaskItem[]? ReferencePathsToDelete { get; set; }
@@ -36,12 +35,6 @@ public class PublicizeAssemblies : Task
         else if (OutputDirectory is null)
         {
             Log.LogError(nameof(OutputDirectory) + " was null!");
-            return false;
-        }
-
-        if (!bool.TryParse(PublicizeAsReferenceAssemblies, out var publicizeAsReferenceAssemblies))
-        {
-            Log.LogError(nameof(PublicizeAsReferenceAssemblies) + " cannot be parsed as bool.");
             return false;
         }
 
@@ -127,7 +120,7 @@ public class PublicizeAssemblies : Task
             {
                 using ModuleDef module = ModuleDefMD.Load(assemblyPath);
 
-                PublicizeAssembly(module, assemblyPublicizes, assemblyDoNotPublicizes, publicizeAsReferenceAssemblies);
+                PublicizeAssembly(module, assemblyPublicizes, assemblyDoNotPublicizes);
 
                 using var fileStream = new FileStream(outputAssemblyPath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
                 module.Write(fileStream);
@@ -176,8 +169,7 @@ public class PublicizeAssemblies : Task
     private static void PublicizeAssembly(
         ModuleDef module,
         List<string> publicizePatterns,
-        List<string> doNotPublicizePatterns,
-        bool publicizeAsReferenceAssemblies)
+        List<string> doNotPublicizePatterns)
     {
         var publicizeAll = publicizePatterns.Any(x => x == module.Assembly.Name);
         var doNotPublicizePropertyMethods = new List<MethodDef>();
@@ -218,7 +210,7 @@ public class PublicizeAssemblies : Task
 
                 if (shouldPublicizeProperty)
                 {
-                    AssemblyEditor.PublicizeProperty(propertyDef, publicizeAsReferenceAssemblies);
+                    AssemblyEditor.PublicizeProperty(propertyDef);
                     publicizedAnyMember = true;
                 }
             }
@@ -234,7 +226,7 @@ public class PublicizeAssemblies : Task
 
                 if (shouldPublicizeMethod)
                 {
-                    AssemblyEditor.PublicizeMethod(methodDef, publicizeAsReferenceAssemblies);
+                    AssemblyEditor.PublicizeMethod(methodDef);
                     publicizedAnyMember = true;
                 }
             }


### PR DESCRIPTION
Removes the option to turn publicized assemblies into reference assemblies (stripping method bodies).

I consider the feature to be out of scope for this project, and most devs seem to turn it off in favor of being able to inspect code at compile time.

Whether the feature should be re-added can be discussed if people turn out missing it.