### PR TITLE
Remove redundant dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/src/Publicizer/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "enhancement"
-    assignees:
-      - "krafs"
-      
-  - package-ecosystem: "nuget"
-    directory: "/src/Publicizer.Tests/"
+    directory: "/"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
The project is currently getting double dependabot version bumps. This change repoints dependabot to look at the .sln-file instead of the individual .csproj-files.