### PR TITLE
Write assemblies to disk with KeepOldMaxStack-flag

### DIFF
--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -27,7 +27,7 @@
     <PackageTags>msbuild accesschecks public publicizer</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>2.0.0</Version>
+    <Version>2.0.1-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -27,7 +27,7 @@
     <PackageTags>msbuild accesschecks public publicizer</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>2.0.1-beta</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds writing publicized assemblies to disk with the `KeepOldMaxStack`-flag.
This avoids [MSB4018](https://docs.microsoft.com/en-us/visualstudio/msbuild/errors/msb4018?view=vs-2022) errors due to dnlib not being able to calculate the max stack value for some specially compiled assemblies.

Closes #42.