### PR TITLE
Add option to ignore all virtual members

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This compiles just fine. However, during execution the runtime is presumably loa
 So you have a Student class with a public Name-property overriding a protected Name-property on the Person class. 
 This will cause an access check mismatch at runtime and throw an error.
 
-You can avoid this by instructing Publicizer to not publicize Person.Name. Use the _DoNotPublicize_-item for this:
+You can avoid this by instructing Publicizer to not publicize Person.Name. You can use the _DoNotPublicize_-item for this:
 ```xml
 <ItemGroup>
     <Publicize Include="ExampleAssembly" />
@@ -102,26 +102,30 @@ You can avoid this by instructing Publicizer to not publicize Person.Name. Use t
 </ItemGroup>
 ```
 
+However, if there is a lot of protected members you have to override, doing this for all of them can be cumbersome.
+For this scenario, you can instruct Publicizer to ignore all virtual members in the assembly:
+```xml
+<ItemGroup>
+    <Publicize Include="ExampleAssembly" IncludeVirtualMembers="false" />
+</ItemGroup>
+```
+
 ### Compiler-generated member name conflicts
 Sometimes assemblies contain members generated automatically by the compiler, like backing-fields for events. 
 These generated members sometimes have names that conflict with other member names when they become public.
 
-You can solve this the same way as above - using _DoNotPublicize_-items.
-
-However, some assemblies have a lot of generated members, and putting them all in _DoNotPublicize_-items could be cumbersome.
-For this scenario, you can tell Publicizer to ignore all compiler-generated members. 
-Given the assembly is called GameAssembly your config could look like this:
+You can solve this in the same ways as above - either by using individual _DoNotPublicize_-items, or by telling Publicizer to ignore all compiler-generated members in the assembly:
 ```xml
 <ItemGroup>
-    <Publicize Include="GameAssembly" IncludeCompilerGeneratedMembers="false" />
+    <Publicize Include="ExampleAssembly" IncludeCompilerGeneratedMembers="false" />
 </ItemGroup>
 ```
 
-You can still publicize specific compiler-generated members by specifying them explicitly:
+If you opt to ignore all virtual and/or compiler-generated members, you can still publicize specific ignored members by specifying them explicitly:
 ```xml
 <ItemGroup>
-    <Publicize Include="GameAssembly" IncludeCompilerGeneratedMembers="false" />
-    <Publicize Include="GameAssembly:Game.Player.SpecificMember" />
+    <Publicize Include="ExampleAssembly" IncludeCompilerGeneratedMembers="false" IncludeVirtualMembers="false" />
+    <Publicize Include="ExampleAssembly:Example.Person.SpecificMember" />
 </ItemGroup>
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can avoid this by instructing Publicizer to not publicize Person.Name. You c
 </ItemGroup>
 ```
 
-However, if there is a lot of protected members you have to override, doing this for all of them can be cumbersome.
+However, if there are a lot of protected members you have to override, doing this for all of them can be cumbersome.
 For this scenario, you can instruct Publicizer to ignore all virtual members in the assembly:
 ```xml
 <ItemGroup>

--- a/src/Publicizer.Tests/PublicizerTests.cs
+++ b/src/Publicizer.Tests/PublicizerTests.cs
@@ -682,7 +682,7 @@ public class PublicizerTests
     }
 
     [Test]
-    public void PublicizeAssembly_ExceptVirtual_FailsCompileAndPrintsErrorCodeCS0122ForVirtualMethod()
+    public void PublicizeAssembly_ExceptVirtual_FailsCompileAndPrintsErrorCodeCS0122ForVirtualProperty()
     {
         using var libraryFolder = new TemporaryFolder();
         var libraryCodePath = Path.Combine(libraryFolder.Path, "LibraryClass.cs");
@@ -690,8 +690,8 @@ public class PublicizerTests
             namespace LibraryNamespace;
             public class LibraryClass
             {
-                protected virtual string ProtectedVirtualMethod() => "foo";
-                private string PrivateMethod() => "bar";
+                protected virtual string VirtualProtectedProperty => "foo";
+                protected string ProtectedProperty => "bar";
             }
             """;
         File.WriteAllText(libraryCodePath, libraryCode);
@@ -721,8 +721,8 @@ public class PublicizerTests
         var appCodePath = Path.Combine(appFolder.Path, "Program.cs");
         var appCode = """
             var instance = new LibraryNamespace.LibraryClass();
-            _ = instance.ProtectedVirtualMethod();
-            _ = instance.PrivateMethod();
+            _ = instance.VirtualProtectedProperty;
+            _ = instance.ProtectedProperty;
             """;
         File.WriteAllText(appCodePath, appCode);
         var libraryPath = Path.Combine(libraryFolder.Path, "LibraryAssembly.dll");
@@ -754,7 +754,7 @@ public class PublicizerTests
         var buildAppProcess = Runner.Run("dotnet", "build", appCsprojPath);
 
         Assert.That(buildAppProcess.ExitCode, Is.Not.Zero, buildAppProcess.Output);
-        Assert.That(buildAppProcess.Output, Does.Contain("CS0122: 'LibraryClass.ProtectedVirtualMethod()' is inaccessible due to its protection level"));
-        Assert.That(buildAppProcess.Output, Does.Not.Contain("CS0122: 'LibraryClass.PrivateMethod()' is inaccessible due to its protection level"));
+        Assert.That(buildAppProcess.Output, Does.Match("CS0122: 'LibraryClass.VirtualProtectedProperty' is inaccessible due to its protection level"));
+        Assert.That(buildAppProcess.Output, Does.Not.Match("CS0122: 'LibraryClass.ProtectedProperty' is inaccessible due to its protection level"));
     }
 }

--- a/src/Publicizer/AssemblyEditor.cs
+++ b/src/Publicizer/AssemblyEditor.cs
@@ -22,23 +22,26 @@ internal static class AssemblyEditor
         }
     }
 
-    internal static void PublicizeProperty(PropertyDef property)
+    internal static void PublicizeProperty(PropertyDef property, bool includeVirtual = true)
     {
         if (property.GetMethod is MethodDef getMethod)
         {
-            PublicizeMethod(getMethod);
+            PublicizeMethod(getMethod, includeVirtual);
         }
 
         if (property.SetMethod is MethodDef setMethod)
         {
-            PublicizeMethod(setMethod);
+            PublicizeMethod(setMethod, includeVirtual);
         }
     }
 
-    internal static void PublicizeMethod(MethodDef method)
+    internal static void PublicizeMethod(MethodDef method, bool includeVirtual = true)
     {
-        method.Attributes &= ~MethodAttributes.MemberAccessMask;
-        method.Attributes |= MethodAttributes.Public;
+        if (includeVirtual || !method.IsVirtual)
+        {
+            method.Attributes &= ~MethodAttributes.MemberAccessMask;
+            method.Attributes |= MethodAttributes.Public;
+        }
     }
 
     internal static void PublicizeField(FieldDef field)

--- a/src/Publicizer/AssemblyEditor.cs
+++ b/src/Publicizer/AssemblyEditor.cs
@@ -8,8 +8,9 @@ namespace Publicizer;
 /// </summary>
 internal static class AssemblyEditor
 {
-    internal static void PublicizeType(TypeDef type)
+    internal static bool PublicizeType(TypeDef type)
     {
+        var oldAttributes = type.Attributes;
         type.Attributes &= ~TypeAttributes.VisibilityMask;
 
         if (type.IsNested)
@@ -20,33 +21,43 @@ internal static class AssemblyEditor
         {
             type.Attributes |= TypeAttributes.Public;
         }
+        return type.Attributes != oldAttributes;
     }
 
-    internal static void PublicizeProperty(PropertyDef property, bool includeVirtual = true)
+    internal static bool PublicizeProperty(PropertyDef property, bool includeVirtual = true)
     {
+        var publicized = false;
+
         if (property.GetMethod is MethodDef getMethod)
         {
-            PublicizeMethod(getMethod, includeVirtual);
+            publicized |= PublicizeMethod(getMethod, includeVirtual);
         }
 
         if (property.SetMethod is MethodDef setMethod)
         {
-            PublicizeMethod(setMethod, includeVirtual);
+            publicized |= PublicizeMethod(setMethod, includeVirtual);
         }
+
+        return publicized;
     }
 
-    internal static void PublicizeMethod(MethodDef method, bool includeVirtual = true)
+    internal static bool PublicizeMethod(MethodDef method, bool includeVirtual = true)
     {
         if (includeVirtual || !method.IsVirtual)
         {
+            var oldAttributes = method.Attributes;
             method.Attributes &= ~MethodAttributes.MemberAccessMask;
             method.Attributes |= MethodAttributes.Public;
+            return method.Attributes != oldAttributes;
         }
+        return false;
     }
 
-    internal static void PublicizeField(FieldDef field)
+    internal static bool PublicizeField(FieldDef field)
     {
+        var oldAttributes = field.Attributes;
         field.Attributes &= ~FieldAttributes.FieldAccessMask;
         field.Attributes |= FieldAttributes.Public;
+        return field.Attributes != oldAttributes;
     }
 }

--- a/src/Publicizer/Krafs.Publicizer.props
+++ b/src/Publicizer/Krafs.Publicizer.props
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemDefinitionGroup>
-    <Publicize Visible="false" IncludeCompilerGeneratedMembers="true" />
+    <Publicize Visible="false" IncludeCompilerGeneratedMembers="true" IncludeVirtualMembers="true" />
     <DoNotPublicize Visible="false" />
   </ItemDefinitionGroup>
 

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -226,8 +226,7 @@ public class PublicizeAssemblies : Task
                 var explicitlyPublicizeProperty = assemblyContext.PublicizeMemberPatterns.Contains(propertyName);
                 if (explicitlyPublicizeProperty)
                 {
-                    AssemblyEditor.PublicizeProperty(propertyDef);
-                    publicizedAnyMemberInType = true;
+                    publicizedAnyMemberInType |= AssemblyEditor.PublicizeProperty(propertyDef);
                     continue;
                 }
 
@@ -249,8 +248,7 @@ public class PublicizeAssemblies : Task
                         continue;
                     }
 
-                    AssemblyEditor.PublicizeProperty(propertyDef, assemblyContext.IncludeVirtualMembers);
-                    publicizedAnyMemberInType = true;
+                    publicizedAnyMemberInType |= AssemblyEditor.PublicizeProperty(propertyDef, assemblyContext.IncludeVirtualMembers);
                 }
             }
 
@@ -274,8 +272,7 @@ public class PublicizeAssemblies : Task
                 var explicitlyPublicizeMethod = assemblyContext.PublicizeMemberPatterns.Contains(methodName);
                 if (explicitlyPublicizeMethod)
                 {
-                    AssemblyEditor.PublicizeMethod(methodDef);
-                    publicizedAnyMemberInType = true;
+                    publicizedAnyMemberInType |= AssemblyEditor.PublicizeMethod(methodDef);
                     continue;
                 }
 
@@ -297,8 +294,7 @@ public class PublicizeAssemblies : Task
                         continue;
                     }
 
-                    AssemblyEditor.PublicizeMethod(methodDef, assemblyContext.IncludeVirtualMembers);
-                    publicizedAnyMemberInType = true;
+                    publicizedAnyMemberInType |= AssemblyEditor.PublicizeMethod(methodDef, assemblyContext.IncludeVirtualMembers);
                 }
             }
 
@@ -316,8 +312,7 @@ public class PublicizeAssemblies : Task
                 var explicitlyPublicizeField = assemblyContext.PublicizeMemberPatterns.Contains(fieldName);
                 if (explicitlyPublicizeField)
                 {
-                    AssemblyEditor.PublicizeField(fieldDef);
-                    publicizedAnyMemberInType = true;
+                    publicizedAnyMemberInType |= AssemblyEditor.PublicizeField(fieldDef);
                     continue;
                 }
 
@@ -339,8 +334,7 @@ public class PublicizeAssemblies : Task
                         continue;
                     }
 
-                    AssemblyEditor.PublicizeField(fieldDef);
-                    publicizedAnyMemberInType = true;
+                    publicizedAnyMemberInType |= AssemblyEditor.PublicizeField(fieldDef);
                 }
             }
 
@@ -358,8 +352,7 @@ public class PublicizeAssemblies : Task
             var explicitlyPublicizeType = assemblyContext.PublicizeMemberPatterns.Contains(typeName);
             if (explicitlyPublicizeType)
             {
-                AssemblyEditor.PublicizeType(typeDef);
-                publicizedAnyMemberInAssembly = true;
+                publicizedAnyMemberInAssembly |= AssemblyEditor.PublicizeType(typeDef);
                 continue;
             }
 
@@ -376,8 +369,7 @@ public class PublicizeAssemblies : Task
                     continue;
                 }
 
-                AssemblyEditor.PublicizeType(typeDef);
-                publicizedAnyMemberInAssembly = true;
+                publicizedAnyMemberInAssembly |= AssemblyEditor.PublicizeType(typeDef);
             }
         }
 

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -342,6 +342,7 @@ public class PublicizeAssemblies : Task
             {
                 AssemblyEditor.PublicizeType(typeDef);
                 publicizedAnyMemberInAssembly = true;
+                continue;
             }
 
             if (explicitlyDoNotPublicizeType)

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -130,6 +130,7 @@ public class PublicizeAssemblies : Task
             if (isAssemblyPattern)
             {
                 assemblyContext.IncludeCompilerGeneratedMembers = item.IncludeCompilerGeneratedMembers();
+                assemblyContext.IncludeVirtualMembers = item.IncludeVirtualMembers();
                 assemblyContext.ExplicitlyPublicizeAssembly = true;
             }
             else
@@ -169,6 +170,7 @@ public class PublicizeAssemblies : Task
         var sb = new StringBuilder();
         sb.Append(assemblyContext.AssemblyName);
         sb.Append(assemblyContext.IncludeCompilerGeneratedMembers);
+        sb.Append(assemblyContext.IncludeVirtualMembers);
         sb.Append(assemblyContext.ExplicitlyPublicizeAssembly);
         sb.Append(assemblyContext.ExplicitlyDoNotPublicizeAssembly);
         foreach (var publicizePattern in assemblyContext.PublicizeMemberPatterns)
@@ -247,7 +249,7 @@ public class PublicizeAssemblies : Task
                         continue;
                     }
 
-                    AssemblyEditor.PublicizeProperty(propertyDef);
+                    AssemblyEditor.PublicizeProperty(propertyDef, assemblyContext.IncludeVirtualMembers);
                     publicizedAnyMemberInType = true;
                 }
             }
@@ -295,7 +297,7 @@ public class PublicizeAssemblies : Task
                         continue;
                     }
 
-                    AssemblyEditor.PublicizeMethod(methodDef);
+                    AssemblyEditor.PublicizeMethod(methodDef, assemblyContext.IncludeVirtualMembers);
                     publicizedAnyMemberInType = true;
                 }
             }

--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -27,7 +27,7 @@
     <PackageTags>msbuild accesschecks public publicizer</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>2.1.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -27,7 +27,7 @@
     <PackageTags>msbuild accesschecks public publicizer</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="\"/>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <Content Include="Krafs.Publicizer.props" PackagePath="build" />
     <Content Include="Krafs.Publicizer.targets" PackagePath="build" />
     <Compile Remove="IgnoresAccessChecksToAttribute.cs" />

--- a/src/Publicizer/PublicizerAssemblyContext.cs
+++ b/src/Publicizer/PublicizerAssemblyContext.cs
@@ -12,6 +12,7 @@ internal sealed class PublicizerAssemblyContext
     internal string AssemblyName { get; }
     internal bool ExplicitlyPublicizeAssembly { get; set; } = false;
     internal bool IncludeCompilerGeneratedMembers { get; set; } = true;
+    internal bool IncludeVirtualMembers { get; set; } = true;
     internal bool ExplicitlyDoNotPublicizeAssembly { get; set; } = false;
     internal HashSet<string> PublicizeMemberPatterns { get; } = new HashSet<string>();
     internal HashSet<string> DoNotPublicizeMemberPatterns { get; } = new HashSet<string>();

--- a/src/Publicizer/TaskItemExtensions.cs
+++ b/src/Publicizer/TaskItemExtensions.cs
@@ -23,4 +23,14 @@ internal static class TaskItemExtensions
 
         return true;
     }
+
+    internal static bool IncludeVirtualMembers(this ITaskItem item)
+    {
+        if (bool.TryParse(item.GetMetadata("IncludeVirtualMembers"), out var includeVirtualMembers))
+        {
+            return includeVirtualMembers;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
Similarly to `IncludeCompilerGeneratedMembers`, adds optional metadata `IncludeVirtualMembers`.
When it is set to false, all virtual members in the assembly are exempt from publicizing (unless specified explicitly).
The default value is true, to not alter previously expected behaviour.