### PR TITLE
Fix assemblies only being publicized if a Type has been publicized

### DIFF
--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -151,7 +151,7 @@ public sealed class PublicizeAssemblies : Task
         ReferencePathsToDelete = referencePathsToDelete.ToArray();
         ReferencePathsToAdd = referencePathsToAdd.ToArray();
 
-        logger.Info($"Successfully publicized {assemblyContexts.Count} assemblies. Terminating task.");
+        logger.Info($"Finished processing {assemblyContexts.Count} assemblies. Terminating task.");
 
         return true;
     }

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -264,6 +264,7 @@ public sealed class PublicizeAssemblies : Task
                     if (AssemblyEditor.PublicizeProperty(propertyDef))
                     {
                         publicizedAnyMemberInType = true;
+                        publicizedAnyMemberInAssembly = true;
                         publicizedPropertiesCount++;
                         logger.Verbose($"Explicitly publicizing property: {propertyName}");
                     }
@@ -291,6 +292,7 @@ public sealed class PublicizeAssemblies : Task
                     if (AssemblyEditor.PublicizeProperty(propertyDef, assemblyContext.IncludeVirtualMembers))
                     {
                         publicizedAnyMemberInType = true;
+                        publicizedAnyMemberInAssembly = true;
                         publicizedPropertiesCount++;
                     }
                 }
@@ -320,6 +322,7 @@ public sealed class PublicizeAssemblies : Task
                     if (AssemblyEditor.PublicizeMethod(methodDef))
                     {
                         publicizedAnyMemberInType = true;
+                        publicizedAnyMemberInAssembly = true;
                         publicizedMethodsCount++;
                         logger.Verbose($"Explicitly publicizing method: {methodName}");
                     }
@@ -347,6 +350,7 @@ public sealed class PublicizeAssemblies : Task
                     if (AssemblyEditor.PublicizeMethod(methodDef, assemblyContext.IncludeVirtualMembers))
                     {
                         publicizedAnyMemberInType = true;
+                        publicizedAnyMemberInAssembly = true;
                         publicizedMethodsCount++;
                     }
                 }
@@ -370,6 +374,7 @@ public sealed class PublicizeAssemblies : Task
                     if (AssemblyEditor.PublicizeField(fieldDef))
                     {
                         publicizedAnyMemberInType = true;
+                        publicizedAnyMemberInAssembly = true;
                         publicizedFieldsCount++;
                         logger.Verbose($"Explicitly publicizing field: {fieldName}");
                     }
@@ -397,6 +402,7 @@ public sealed class PublicizeAssemblies : Task
                     if (AssemblyEditor.PublicizeField(fieldDef))
                     {
                         publicizedAnyMemberInType = true;
+                        publicizedAnyMemberInAssembly = true;
                         publicizedFieldsCount++;
                     }
                 }


### PR DESCRIPTION
An assembly is currently marked as publicized only if one of its `Types` changes from non-public to public. In the case of publicizing e.g. a private field in a Type that is already public makes the task resolve the Type as unmodified, and if that field is the only publicized member in the assembly the entire assembly resolves as unmodified.

This fix makes it so that any member being publicized marks the assembly as modified and saved to disk.