### PR TITLE
Adds support for regular expressions in member names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4.1.0
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
       env:
         DOTNET_NOLOGO: true
         DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Publicizer needs to be told what private members you want access to. You do this
     <!-- All members in an assembly -->
     <Publicize Include="MyAssemblyFileName" />
 
+    <!-- Type -->
+    <Publicize Include="MyAssemblyFileName:MyNamespace.MyType" />
+
+    <!-- Generic Type -->
+    <!-- The number represents the arity/number of generic type arguments -->
+    <Publicize Include="MyAssemblyFileName:MyNamespace.MyType`2" />
+    
     <!-- Field -->
     <Publicize Include="MyAssemblyFileName:MyNamespace.MyType.myField" />
 
@@ -26,12 +33,21 @@ Publicizer needs to be told what private members you want access to. You do this
 
     <!-- Method -->
     <Publicize Include="MyAssemblyFileName:MyNamespace.MyType.MyMethod" />
-
+    
     <!-- Field in nested type -->
     <Publicize Include="MyAssemblyFileName:MyNamespace.MyType+MyNestedType.myField" />
 
     <!-- Constructor -->
     <Publicize Include="MyAssemblyFileName:MyNamespace.MyType..ctor" />
+</ItemGroup>
+```
+
+### Regular expressions
+Regular expressions are supported with the `MemberPattern` attribute.
+```xml
+<ItemGroup>
+    <!-- All members in a type -->
+    <Publicize Include="MyAssemblyFileName" MemberPattern="^MyNamespace\.MyType\..*" />
 </ItemGroup>
 ```
 

--- a/src/Publicizer.Tests/Publicizer.Tests.csproj
+++ b/src/Publicizer.Tests/Publicizer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1702</NoWarn>

--- a/src/Publicizer.Tests/PublicizerTests.cs
+++ b/src/Publicizer.Tests/PublicizerTests.cs
@@ -763,15 +763,15 @@ public class PublicizerTests
     {
         using var libraryFolder = new TemporaryFolder();
         string libraryCodePath = Path.Combine(libraryFolder.Path, "PrivateClass.cs");
-        string libraryCode = """
+        string libraryCode = """"
             namespace PrivateNamespace;
             class PrivateClass
             {
-                private static string PrivateFooField = "foo";
-                private static string PrivateBarField = "bar";
-                private static string PrivateFooProperty { get; } = "foo";
+                private string PrivateFooField = "foo";
+                private string PrivateBarField = "bar";
+                private string PrivateFooProperty { get; } = "foo";
             }
-            """;
+            """";
         File.WriteAllText(libraryCodePath, libraryCode);
 
         string libraryCsprojPath = Path.Combine(libraryFolder.Path, "PrivateAssembly.csproj");
@@ -798,9 +798,10 @@ public class PublicizerTests
         using var appFolder = new TemporaryFolder();
         string appCodePath = Path.Combine(appFolder.Path, "Program.cs");
         string appCode = """
-                         _ = PrivateNamespace.PrivateClass.PrivateFooField;
-                         _ = PrivateNamespace.PrivateClass.PrivateBarField;
-                         _ = PrivateNamespace.PrivateClass.PrivateFooProperty;
+                         var instance = new PrivateNamespace.PrivateClass();
+                         _ = instance.PrivateFooField;
+                         _ = instance.PrivateBarField;
+                         _ = instance.PrivateFooProperty;
                          """;
         File.WriteAllText(appCodePath, appCode);
         string libraryPath = Path.Combine(libraryFolder.Path, "PrivateAssembly.dll");
@@ -824,7 +825,7 @@ public class PublicizerTests
 
             </Project>
             """;
-
+    
         string appCsprojPath = Path.Combine(appFolder.Path, "App.csproj");
         File.WriteAllText(appCsprojPath, appCsproj);
         string appPath = Path.Combine(appFolder.Path, "App.dll");

--- a/src/Publicizer.Tests/PublicizerTests.cs
+++ b/src/Publicizer.Tests/PublicizerTests.cs
@@ -769,7 +769,7 @@ public class PublicizerTests
             {
                 private static string PrivateFooField = "foo";
                 private static string PrivateBarField = "bar";
-                private static string PrivateFooProperty = { get; } = "foo";
+                private static string PrivateFooProperty { get; } = "foo";
             }
             """;
         File.WriteAllText(libraryCodePath, libraryCode);

--- a/src/Publicizer.Tests/PublicizerTests.cs
+++ b/src/Publicizer.Tests/PublicizerTests.cs
@@ -767,9 +767,9 @@ public class PublicizerTests
             namespace PrivateNamespace;
             class PrivateClass
             {
-                private string PrivateFooField = "foo";
-                private string PrivateBarField = "bar";
-                private string PrivateFooProperty { get; } = "foo";
+                protected string PrivateFooField = "foo";
+                protected string PrivateBarField = "bar";
+                protected string PrivateFooProperty { get; } = "foo";
             }
             """";
         File.WriteAllText(libraryCodePath, libraryCode);

--- a/src/Publicizer.Tests/PublicizerTests.cs
+++ b/src/Publicizer.Tests/PublicizerTests.cs
@@ -833,8 +833,8 @@ public class PublicizerTests
 
         ProcessResult buildAppProcess = Runner.Run("dotnet", "build", appCsprojPath);
         Assert.That(buildAppProcess.ExitCode, Is.Not.Zero, buildAppProcess.Output);
-        Assert.That(buildAppProcess.Output, Does.Match("CS0122: 'PrivateNamespace.PrivateClass.PrivateBarField' is inaccessible due to its protection level"));
-        Assert.That(buildAppProcess.Output, Does.Not.Match("CS0122: 'PrivateNamespace.PrivateClass.PrivateFooField' is inaccessible due to its protection level"));
-        Assert.That(buildAppProcess.Output, Does.Not.Match("CS0122: 'PrivateNamespace.PrivateClass.PrivateFooProperty' is inaccessible due to its protection level"));
+        Assert.That(buildAppProcess.Output, Does.Match("CS0122: 'PrivateClass.PrivateBarField' is inaccessible due to its protection level"));
+        Assert.That(buildAppProcess.Output, Does.Not.Match("CS0122: 'PrivateClass.PrivateFooField' is inaccessible due to its protection level"));
+        Assert.That(buildAppProcess.Output, Does.Not.Match("CS0122: 'PrivateClass.PrivateFooProperty' is inaccessible due to its protection level"));
     }
 }

--- a/src/Publicizer.Tests/PublicizerTests.cs
+++ b/src/Publicizer.Tests/PublicizerTests.cs
@@ -5,7 +5,7 @@ namespace Publicizer.Tests;
 
 public class PublicizerTests
 {
-    private const string TestTargetFramework = "net8.0";
+    private const string TestTargetFramework = "net9.0";
 
     [Test]
     public void PublicizePrivateField_CompilesAndRunsWithExitCode0AndPrintsFieldValue()

--- a/src/Publicizer.Tests/PublicizerTests.cs
+++ b/src/Publicizer.Tests/PublicizerTests.cs
@@ -831,11 +831,7 @@ public class PublicizerTests
         NugetConfigMaker.CreateConfigThatRestoresPublicizerLocally(appFolder.Path);
 
         ProcessResult buildAppProcess = Runner.Run("dotnet", "build", appCsprojPath);
-        ProcessResult runAppProcess = Runner.Run("dotnet", appPath);
-
-        Assert.That(buildAppProcess.ExitCode, Is.Zero, buildAppProcess.Output);
-        Assert.That(runAppProcess.ExitCode, Is.Zero, runAppProcess.Output);
-        
+        Assert.That(buildAppProcess.ExitCode, Is.Not.Zero, buildAppProcess.Output);
         Assert.That(buildAppProcess.Output, Does.Match("CS0122: 'PrivateNamespace.PrivateClass.PrivateBarField' is inaccessible due to its protection level"));
         Assert.That(buildAppProcess.Output, Does.Not.Match("CS0122: 'PrivateNamespace.PrivateClass.PrivateFooField' is inaccessible due to its protection level"));
         Assert.That(buildAppProcess.Output, Does.Not.Match("CS0122: 'PrivateNamespace.PrivateClass.PrivateFooProperty' is inaccessible due to its protection level"));

--- a/src/Publicizer/Hasher.cs
+++ b/src/Publicizer/Hasher.cs
@@ -26,10 +26,14 @@ internal static class Hasher
         {
             sb.Append(doNotPublicizePattern);
         }
+        if (assemblyContext.PublicizeMemberRegexPattern is not null)
+        {
+            sb.Append(assemblyContext.PublicizeMemberRegexPattern.ToString());
+        }
 
-        byte[] patternbytes = Encoding.UTF8.GetBytes(sb.ToString());
+        byte[] patternBytes = Encoding.UTF8.GetBytes(sb.ToString());
         byte[] assemblyBytes = File.ReadAllBytes(assemblyPath);
-        byte[] allBytes = assemblyBytes.Concat(patternbytes).ToArray();
+        byte[] allBytes = assemblyBytes.Concat(patternBytes).ToArray();
 
         return ComputeHash(allBytes);
     }

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -238,7 +238,6 @@ public sealed class PublicizeAssemblies : Task
             string typeName = typeDef.ReflectionFullName;
 
             bool explicitlyDoNotPublicizeType = assemblyContext.DoNotPublicizeMemberPatterns.Contains(typeName);
-            explicitlyDoNotPublicizeType |= assemblyContext.PublicizeMemberRegexPattern.IsMatch(typeName);
             
             // PROPERTIES
             foreach (PropertyDef? propertyDef in typeDef.Properties)
@@ -261,7 +260,6 @@ public sealed class PublicizeAssemblies : Task
                 }
 
                 bool explicitlyPublicizeProperty = assemblyContext.PublicizeMemberPatterns.Contains(propertyName);
-                explicitlyPublicizeProperty |= assemblyContext.PublicizeMemberRegexPattern.IsMatch(propertyName);
                 if (explicitlyPublicizeProperty)
                 {
                     if (AssemblyEditor.PublicizeProperty(propertyDef))
@@ -292,7 +290,7 @@ public sealed class PublicizeAssemblies : Task
                         continue;
                     }
                     
-                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern.IsMatch(propertyName);
+                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(propertyName) ?? true;
                     if (!isRegexPatternMatch)
                     {
                         continue;
@@ -356,7 +354,7 @@ public sealed class PublicizeAssemblies : Task
                         continue;
                     }
                     
-                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern.IsMatch(methodName);
+                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(methodName) ?? true;
                     if (!isRegexPatternMatch)
                     {
                         continue;
@@ -414,7 +412,7 @@ public sealed class PublicizeAssemblies : Task
                         continue;
                     }
                     
-                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern.IsMatch(fieldName);
+                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(fieldName) ?? true;
                     if (!isRegexPatternMatch)
                     {
                         continue;
@@ -470,7 +468,7 @@ public sealed class PublicizeAssemblies : Task
                     continue;
                 }
 
-                bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern.IsMatch(typeName);
+                bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(typeName) ?? true;
                 if (!isRegexPatternMatch)
                 {
                     continue;

--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -20,7 +20,7 @@
     <Title>Publicizer</Title>
     <PackageId>Krafs.Publicizer</PackageId>
     <Authors>Krafs</Authors>
-    <Copyright>© Krafs 2023</Copyright>
+    <Copyright>© Krafs 2024</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/krafs/Publicizer</PackageProjectUrl>
     <RepositoryUrl>https://github.com/krafs/Publicizer.git</RepositoryUrl>
@@ -28,7 +28,7 @@
     <PackageTags>msbuild accesschecks public publicizer</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>2.2.1</Version>
+    <Version>2.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Publicizer/PublicizerAssemblyContext.cs
+++ b/src/Publicizer/PublicizerAssemblyContext.cs
@@ -16,6 +16,6 @@ internal sealed class PublicizerAssemblyContext
     internal bool IncludeVirtualMembers { get; set; } = true;
     internal bool ExplicitlyDoNotPublicizeAssembly { get; set; } = false;
     internal HashSet<string> PublicizeMemberPatterns { get; } = new HashSet<string>();
-    internal Regex PublicizeMemberRegexPattern { get; set; }
+    internal Regex? PublicizeMemberRegexPattern { get; set; }
     internal HashSet<string> DoNotPublicizeMemberPatterns { get; } = new HashSet<string>();
 }

--- a/src/Publicizer/PublicizerAssemblyContext.cs
+++ b/src/Publicizer/PublicizerAssemblyContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Publicizer;
 
@@ -15,5 +16,6 @@ internal sealed class PublicizerAssemblyContext
     internal bool IncludeVirtualMembers { get; set; } = true;
     internal bool ExplicitlyDoNotPublicizeAssembly { get; set; } = false;
     internal HashSet<string> PublicizeMemberPatterns { get; } = new HashSet<string>();
+    internal Regex PublicizeMemberRegexPattern { get; set; }
     internal HashSet<string> DoNotPublicizeMemberPatterns { get; } = new HashSet<string>();
 }

--- a/src/Publicizer/TaskItemExtensions.cs
+++ b/src/Publicizer/TaskItemExtensions.cs
@@ -5,8 +5,6 @@ namespace Publicizer;
 
 internal static class TaskItemExtensions
 {
-    private static readonly Regex s_matchAll =  new(".*", RegexOptions.Compiled);
-    
     internal static string FileName(this ITaskItem item)
     {
         return item.GetMetadata("Filename");
@@ -37,12 +35,12 @@ internal static class TaskItemExtensions
         return true;
     }
     
-    internal static Regex MemberPattern(this ITaskItem item)
+    internal static Regex? MemberPattern(this ITaskItem item)
     {
         string? memberPattern = item.GetMetadata("MemberPattern");
         if (string.IsNullOrWhiteSpace(memberPattern))
         {
-            return s_matchAll;
+            return null;
         }
 
         return new Regex(memberPattern, RegexOptions.Compiled);

--- a/src/Publicizer/TaskItemExtensions.cs
+++ b/src/Publicizer/TaskItemExtensions.cs
@@ -1,9 +1,12 @@
+using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 
 namespace Publicizer;
 
 internal static class TaskItemExtensions
 {
+    private static readonly Regex s_matchAll =  new(".*", RegexOptions.Compiled);
+    
     internal static string FileName(this ITaskItem item)
     {
         return item.GetMetadata("Filename");
@@ -32,5 +35,16 @@ internal static class TaskItemExtensions
         }
 
         return true;
+    }
+    
+    internal static Regex MemberPattern(this ITaskItem item)
+    {
+        string? memberPattern = item.GetMetadata("MemberPattern");
+        if (string.IsNullOrWhiteSpace(memberPattern))
+        {
+            return s_matchAll;
+        }
+
+        return new Regex(memberPattern, RegexOptions.Compiled);
     }
 }


### PR DESCRIPTION
This PR adds support for matching against member names in a particular assembly with regular expressions.

For example, it is now possible to publicize all members in a given type with:
```xml
<ItemGroup>
    <Publicize Include="MyAssembly" MemberPattern="^MyNamespace\.MyType\..*" />
</ItemGroup>
```
Note: `MemberPattern` is only valid on `Publicize` items that only have the assembly specified in the `Include`.