### PR TITLE
Ignore CS0436 in IgnoresAccessChecksToAttribute.cs

### DIFF
--- a/src/Publicizer/IgnoresAccessChecksToAttribute.cs
+++ b/src/Publicizer/IgnoresAccessChecksToAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace System.Runtime.CompilerServices
+﻿#pragma warning disable CS0436 // Type conflicts with imported type
+
+namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     internal sealed class IgnoresAccessChecksToAttribute : Attribute


### PR DESCRIPTION
This is a really obscure issue:

When referencing [MonoMod.Utils](https://github.com/MonoMod/MonoMod), a warning gets emitted:

> MyProject.AssemblyInfo.cs(13,44): Warning CS0436 : The type 'IgnoresAccessChecksToAttribute' in 'C:\Users\...\.nuget\packages\krafs.publicizer\2.3.0\contentfiles\cs\any\Publicizer\IgnoresAccessChecksToAttribute.cs' conflicts with the imported type 'IgnoresAccessChecksToAttribute' in 'MonoMod.Utils, Version=22.1.29.1, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'C:\Users\...\.nuget\packages\krafs.publicizer\2.3.0\contentfiles\cs\any\Publicizer\IgnoresAccessChecksToAttribute.cs'.

This is because [their type](https://github.com/MonoMod/MonoMod/blob/26a0a4d22fcd233dd22db4fd034cb3ac41420fd4/src/MonoMod.Utils/IgnoresAccessChecksToAttribute.cs) is public, not internal.

BepInEx's publicizer [had the same issue](https://github.com/BepInEx/BepInEx.AssemblyPublicizer/issues/5), but much more prevalent, due to including MonoMod.Utils in the main BepInEx package. It was fixed in [the same way](https://github.com/BepInEx/BepInEx.AssemblyPublicizer/commit/75b77ea42057bbc7d89b318f24138e328ec6817f).

Thanks for your time, and thanks for making such a great tool! Totally understandable if this is too wonky of a pull request to accept (should probably try to fix it upstream in MonoMod.Utils as well, will try to do so when I have time - this PR would still be useful, though, for old versions of MonoMod that tend to hang around in games for ages)