### PR TITLE
Added OriginalAccessModifierAttribute.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ﻿.vs
 bin/
 obj/
-*.csproj.user
+*.user
+.idea/

--- a/src/Publicizer/AssemblyEditor.cs
+++ b/src/Publicizer/AssemblyEditor.cs
@@ -1,13 +1,32 @@
+using System;
+using System.Linq;
 using dnlib.DotNet;
+using FieldAttributes = dnlib.DotNet.FieldAttributes;
+using MethodAttributes = dnlib.DotNet.MethodAttributes;
+using TypeAttributes = dnlib.DotNet.TypeAttributes;
 
 namespace Publicizer;
 
 /// <summary>
 /// Class for making edits to assemblies and related types.
 /// </summary>
-internal static class AssemblyEditor
+internal class AssemblyEditor
 {
-    internal static bool PublicizeType(TypeDef type)
+    private readonly ModuleDef _module;
+    private readonly bool _addOriginalAccessModifierAttribute;
+    internal AssemblyEditor(ModuleDef module, bool addOriginalAccessModifierAttribute)
+    {
+        _module = module;
+        _addOriginalAccessModifierAttribute = addOriginalAccessModifierAttribute;
+    }
+
+    internal bool publicizedAnyMemberInAssembly;
+    internal int publicizedTypesCount;
+    internal int publicizedPropertiesCount;
+    internal int publicizedMethodsCount;
+    internal int publicizedFieldsCount;
+
+    internal bool PublicizeType(TypeDef type)
     {
         TypeAttributes oldAttributes = type.Attributes;
         type.Attributes &= ~TypeAttributes.VisibilityMask;
@@ -20,10 +39,17 @@ internal static class AssemblyEditor
         {
             type.Attributes |= TypeAttributes.Public;
         }
-        return type.Attributes != oldAttributes;
+
+        if (type.Attributes != oldAttributes)
+        {
+            AddOriginalAccessModifierAttribute(type, ConvertAttributes(oldAttributes));
+            publicizedTypesCount++;
+            return true;
+        }
+        return false;
     }
 
-    internal static bool PublicizeProperty(PropertyDef property, bool includeVirtual = true)
+    internal bool PublicizeProperty(PropertyDef property, bool includeVirtual = true)
     {
         bool publicized = false;
 
@@ -37,26 +63,136 @@ internal static class AssemblyEditor
             publicized |= PublicizeMethod(setMethod, includeVirtual);
         }
 
+        if (publicized)
+        {
+            publicizedPropertiesCount++;
+        }
         return publicized;
     }
 
-    internal static bool PublicizeMethod(MethodDef method, bool includeVirtual = true)
+    internal bool PublicizeMethod(MethodDef method, bool includeVirtual = true)
     {
         if (includeVirtual || !method.IsVirtual)
         {
             MethodAttributes oldAttributes = method.Attributes;
             method.Attributes &= ~MethodAttributes.MemberAccessMask;
             method.Attributes |= MethodAttributes.Public;
-            return method.Attributes != oldAttributes;
+            if (method.Attributes != oldAttributes)
+            {
+                AddOriginalAccessModifierAttribute(method, ConvertAttributes(oldAttributes));
+                publicizedAnyMemberInAssembly = true;
+                publicizedMethodsCount++;
+                return true;
+            }
         }
         return false;
     }
 
-    internal static bool PublicizeField(FieldDef field)
+    internal bool PublicizeField(FieldDef field)
     {
         FieldAttributes oldAttributes = field.Attributes;
         field.Attributes &= ~FieldAttributes.FieldAccessMask;
         field.Attributes |= FieldAttributes.Public;
-        return field.Attributes != oldAttributes;
+        if (field.Attributes != oldAttributes)
+        {
+            AddOriginalAccessModifierAttribute(field, ConvertAttributes(oldAttributes));
+            publicizedAnyMemberInAssembly = true;
+            publicizedFieldsCount++;
+            return true;
+        }
+        return false;
+    }
+
+    private MethodDef? _attributeConstructor;
+    private void AddOriginalAccessModifierAttribute(IHasCustomAttribute item, AccessModifier original)
+    {
+        if (!_addOriginalAccessModifierAttribute)
+        {
+            return;
+        }
+        if (_attributeConstructor == null)
+        {
+            string @namespace = new UTF8String(nameof(Publicizer));
+            string name = new UTF8String("OriginalAccessModifierAttribute");
+            TypeDef? attributeTypeDef = _module.Types.FirstOrDefault(t => t.Namespace == @namespace && t.Name == name);
+            if (attributeTypeDef == null)
+            {
+                ITypeDefOrRef attributeBaseTypeRef = _module.Import(typeof(Attribute))!;
+                attributeTypeDef = new TypeDefUser(@namespace, name, attributeBaseTypeRef);
+                attributeTypeDef.Attributes = TypeAttributes.NotPublic | TypeAttributes.Sealed;
+
+                var methodSig = MethodSig.CreateInstance(
+                    _module.CorLibTypes.Void,
+                    _module.CorLibTypes.String
+                );
+                var methodDef = new MethodDefUser(".ctor", methodSig);
+
+                attributeTypeDef.Methods.Add(methodDef);
+            }
+            _attributeConstructor = attributeTypeDef.FindConstructors().First();
+        }
+        var attribute = new CustomAttribute(_attributeConstructor);
+        var caArgument = new CAArgument(_module.CorLibTypes.String, AccessModifierToString(original));
+        attribute.ConstructorArguments.Add(caArgument);
+        item.CustomAttributes.Add(attribute);
+    }
+
+    private static AccessModifier ConvertAttributes(TypeAttributes attributes)
+    {
+        attributes &= ~TypeAttributes.VisibilityMask;
+        return attributes switch
+        {
+            TypeAttributes.NotPublic => AccessModifier.Private,
+            TypeAttributes.Public => AccessModifier.Public,
+            TypeAttributes.NestedPublic => AccessModifier.Public,
+            TypeAttributes.NestedPrivate => AccessModifier.Private,
+            TypeAttributes.NestedFamily => AccessModifier.Protected,
+            TypeAttributes.NestedAssembly => AccessModifier.Internal,
+            TypeAttributes.NestedFamANDAssem => AccessModifier.PrivateProtected,
+            TypeAttributes.NestedFamORAssem => AccessModifier.ProtectedInternal,
+            _ => AccessModifier.File
+        };
+    }
+    private static AccessModifier ConvertAttributes(MethodAttributes attributes)
+    {
+        // methods and fields share the same visibility mask order and values
+        return ConvertAttributes((FieldAttributes)attributes);
+    }
+    private static AccessModifier ConvertAttributes(FieldAttributes attributes)
+    {
+        attributes &= ~FieldAttributes.FieldAccessMask;
+        return attributes switch
+        {
+            FieldAttributes.PrivateScope => AccessModifier.CompilerControlled,
+            FieldAttributes.Private => AccessModifier.Private,
+            FieldAttributes.FamANDAssem => AccessModifier.PrivateProtected,
+            FieldAttributes.Assembly => AccessModifier.Internal,
+            FieldAttributes.Family => AccessModifier.Protected,
+            FieldAttributes.FamORAssem => AccessModifier.ProtectedInternal,
+            FieldAttributes.Public => AccessModifier.Public,
+            _ => AccessModifier.File
+        };
+    }
+    // makes it more readable
+    // corresponds to official documentation
+    // https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers
+    private enum AccessModifier
+    {
+        Public, Private, Protected, Internal, ProtectedInternal, PrivateProtected, File, CompilerControlled
+    }
+    private static string AccessModifierToString(AccessModifier modifier)
+    {
+        return modifier switch
+        {
+            AccessModifier.Public => "public",
+            AccessModifier.Private => "private",
+            AccessModifier.Protected => "protected",
+            AccessModifier.Internal => "internal",
+            AccessModifier.ProtectedInternal => "protected internal",
+            AccessModifier.PrivateProtected => "private protected",
+            AccessModifier.File => "file",
+            AccessModifier.CompilerControlled => "[CompilerControlled|PrivateScope]",
+            _ => throw new ArgumentOutOfRangeException(nameof(modifier), modifier, null)
+        };
     }
 }

--- a/src/Publicizer/AssemblyEditor.cs
+++ b/src/Publicizer/AssemblyEditor.cs
@@ -125,7 +125,7 @@ internal class AssemblyEditor
         TypeDef? attributeTypeDef = module.Types.FirstOrDefault(t => t.Namespace == @namespace && t.Name == name);
         if (attributeTypeDef == null)
         {
-            ITypeDefOrRef attributeBaseTypeRef = module.Import(typeof(Attribute))!;
+            ITypeDefOrRef attributeBaseTypeRef = module.CorLibTypes.GetTypeRef("System", "Attribute");
             attributeTypeDef = new TypeDefUser(@namespace, name, attributeBaseTypeRef);
             attributeTypeDef.Attributes = TypeAttributes.NestedAssembly | TypeAttributes.Sealed;
 

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -221,13 +221,9 @@ public sealed class PublicizeAssemblies : Task
 
     private static bool PublicizeAssembly(ModuleDef module, PublicizerAssemblyContext assemblyContext, ITaskLogger logger)
     {
-        bool publicizedAnyMemberInAssembly = false;
         var doNotPublicizePropertyMethods = new HashSet<MethodDef>();
 
-        int publicizedTypesCount = 0;
-        int publicizedPropertiesCount = 0;
-        int publicizedMethodsCount = 0;
-        int publicizedFieldsCount = 0;
+        var assemblyEditor = new AssemblyEditor(module, assemblyContext.AddOriginalAccessModifierAttribute);
 
         // TYPES
         foreach (TypeDef? typeDef in module.GetTypes())
@@ -262,11 +258,9 @@ public sealed class PublicizeAssemblies : Task
                 bool explicitlyPublicizeProperty = assemblyContext.PublicizeMemberPatterns.Contains(propertyName);
                 if (explicitlyPublicizeProperty)
                 {
-                    if (AssemblyEditor.PublicizeProperty(propertyDef))
+                    if (assemblyEditor.PublicizeProperty(propertyDef))
                     {
                         publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedPropertiesCount++;
                         logger.Verbose($"Explicitly publicizing property: {propertyName}");
                     }
                     continue;
@@ -296,11 +290,9 @@ public sealed class PublicizeAssemblies : Task
                         continue;
                     }
 
-                    if (AssemblyEditor.PublicizeProperty(propertyDef, assemblyContext.IncludeVirtualMembers))
+                    if (assemblyEditor.PublicizeProperty(propertyDef, assemblyContext.IncludeVirtualMembers))
                     {
                         publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedPropertiesCount++;
                     }
                 }
             }
@@ -326,11 +318,9 @@ public sealed class PublicizeAssemblies : Task
                 bool explicitlyPublicizeMethod = assemblyContext.PublicizeMemberPatterns.Contains(methodName);
                 if (explicitlyPublicizeMethod)
                 {
-                    if (AssemblyEditor.PublicizeMethod(methodDef))
+                    if (assemblyEditor.PublicizeMethod(methodDef))
                     {
                         publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedMethodsCount++;
                         logger.Verbose($"Explicitly publicizing method: {methodName}");
                     }
                     continue;
@@ -360,11 +350,9 @@ public sealed class PublicizeAssemblies : Task
                         continue;
                     }
 
-                    if (AssemblyEditor.PublicizeMethod(methodDef, assemblyContext.IncludeVirtualMembers))
+                    if (assemblyEditor.PublicizeMethod(methodDef, assemblyContext.IncludeVirtualMembers))
                     {
                         publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedMethodsCount++;
                     }
                 }
             }
@@ -384,11 +372,9 @@ public sealed class PublicizeAssemblies : Task
                 bool explicitlyPublicizeField = assemblyContext.PublicizeMemberPatterns.Contains(fieldName);
                 if (explicitlyPublicizeField)
                 {
-                    if (AssemblyEditor.PublicizeField(fieldDef))
+                    if (assemblyEditor.PublicizeField(fieldDef))
                     {
                         publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedFieldsCount++;
                         logger.Verbose($"Explicitly publicizing field: {fieldName}");
                     }
                     continue;
@@ -418,22 +404,16 @@ public sealed class PublicizeAssemblies : Task
                         continue;
                     }
 
-                    if (AssemblyEditor.PublicizeField(fieldDef))
+                    if (assemblyEditor.PublicizeField(fieldDef))
                     {
                         publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedFieldsCount++;
                     }
                 }
             }
 
             if (publicizedAnyMemberInType)
             {
-                if (AssemblyEditor.PublicizeType(typeDef))
-                {
-                    publicizedAnyMemberInAssembly = true;
-                    publicizedTypesCount++;
-                }
+                assemblyEditor.PublicizeType(typeDef);
                 continue;
             }
 
@@ -446,10 +426,8 @@ public sealed class PublicizeAssemblies : Task
             bool explicitlyPublicizeType = assemblyContext.PublicizeMemberPatterns.Contains(typeName);
             if (explicitlyPublicizeType)
             {
-                if (AssemblyEditor.PublicizeType(typeDef))
+                if (assemblyEditor.PublicizeType(typeDef))
                 {
-                    publicizedAnyMemberInAssembly = true;
-                    publicizedTypesCount++;
                     logger.Verbose($"Explicitly publicizing type: {typeName}");
                 }
                 continue;
@@ -474,20 +452,16 @@ public sealed class PublicizeAssemblies : Task
                     continue;
                 }
 
-                if (AssemblyEditor.PublicizeType(typeDef))
-                {
-                    publicizedAnyMemberInAssembly = true;
-                    publicizedTypesCount++;
-                }
+                assemblyEditor.PublicizeType(typeDef);
             }
         }
 
-        logger.Info("Publicized types: " + publicizedTypesCount);
-        logger.Info("Publicized properties: " + publicizedPropertiesCount);
-        logger.Info("Publicized methods: " + publicizedMethodsCount);
-        logger.Info("Publicized fields: " + publicizedFieldsCount);
+        logger.Info("Publicized types: " + assemblyEditor.publicizedTypesCount);
+        logger.Info("Publicized properties: " + assemblyEditor.publicizedPropertiesCount);
+        logger.Info("Publicized methods: " + assemblyEditor.publicizedMethodsCount);
+        logger.Info("Publicized fields: " + assemblyEditor.publicizedFieldsCount);
 
-        return publicizedAnyMemberInAssembly;
+        return assemblyEditor.publicizedAnyMemberInAssembly;
     }
 
     private static bool IsCompilerGenerated(IHasCustomAttribute memberDef)

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -226,8 +226,15 @@ public sealed class PublicizeAssemblies : Task
         var assemblyEditor = new AssemblyEditor(module, assemblyContext.AddOriginalAccessModifierAttribute);
 
         // TYPES
-        foreach (TypeDef? typeDef in module.GetTypes())
+        foreach (TypeDef typeDef in module.GetTypes())
         {
+            if (assemblyEditor.IsAccessAttribute(typeDef))
+            {
+                // do not publicize the access attribute itself, keep it internal
+                // also avoids the attribute attributing itself
+                continue;
+            }
+
             doNotPublicizePropertyMethods.Clear();
 
             bool publicizedAnyMemberInType = false;

--- a/src/Publicizer/PublicizerAssemblyContext.cs
+++ b/src/Publicizer/PublicizerAssemblyContext.cs
@@ -14,6 +14,7 @@ internal sealed class PublicizerAssemblyContext
     internal bool ExplicitlyPublicizeAssembly { get; set; } = false;
     internal bool IncludeCompilerGeneratedMembers { get; set; } = true;
     internal bool IncludeVirtualMembers { get; set; } = true;
+    internal bool AddOriginalAccessModifierAttribute { get; set; } = true;
     internal bool ExplicitlyDoNotPublicizeAssembly { get; set; } = false;
     internal HashSet<string> PublicizeMemberPatterns { get; } = new HashSet<string>();
     internal Regex? PublicizeMemberRegexPattern { get; set; }


### PR DESCRIPTION
I recently had to work in Mono.Cecil with CustomAttributes, so I thought I'd try the same here.

Should solve #73.

If it works, it should look something like this:
```csharp
[OriginalAccessModifier("public")]
```
I did not want to just output the original attributes, because nobody knows what NestedFamANDAssem means... so its all nicely mapped as per ms documentation to what we would have in the sources, see https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers .

Feel free to adjust directly the PR/sources as required or give feedback.

Note/TODO (in addition to krafs list):
- I did not test this at all, I don't even know how to.
- `assemblyContext.AddOriginalAccessModifierAttribute` is not being written to by anything, it is just true by default for now.
- ~need to add the fields to the attribute type too, otherwise the attribute is invalid. without those fields it still works for disassemblers (rider, dnspy) but probably will not be nice if actually loading the assembly~ (nvrmd, i think here its just an argument to the constructor without any persistence of the value. my other solution is fields based)