### PR TITLE
Add skip-changelog label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,3 +2,8 @@ documentation:
   - changed-files:
       - any-glob-to-all-files:
           - '**/*.md'
+
+skip-changelog:
+  - changed-files:
+      - any-glob-to-all-files:
+          - '{.github/**,.editorconfig,.gitignore,global.json,Publicizer.slnx,scripts/**,src/Publicizer.Tests/**}'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
       - dependabot
     labels:
       - documentation
+      - skip-changelog
   categories:
     - title: Breaking Changes
       labels:


### PR DESCRIPTION
Auto-labels non-user-facing PRs (infra, tests, tooling, docs) with a new `skip-changelog` label and excludes it from generated release notes.