### PR TITLE
Remove dead Publicized reference metadata

### DIFF
--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -143,7 +143,6 @@ public sealed class PublicizeAssemblies : Task
             referencePathsToDelete.Add(reference);
             ITaskItem newReference = new TaskItem(outputAssemblyPath);
             reference.CopyMetadataTo(newReference);
-            reference.SetMetadata("Publicized", bool.TrueString);
             referencePathsToAdd.Add(newReference);
             scopedLogger.Info("Assembly processing finished");
         }


### PR DESCRIPTION
The `Publicized` metadata was set on the reference that gets removed from `ReferencePath`, so downstream never observed it. Drop the marker rather than fix - no one is consuming it.

No user-visible effect: nothing could read this metadata, so nothing can notice it going away.