### PR TITLE
Run tests on Windows in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ on:
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
Publicizer rewrites net472 assemblies, but CI ran ubuntu-only - Windows-specific Framework/MSBuild-path issues could slip through. Add a `windows-latest` job alongside `ubuntu-latest` via an `os` matrix (`fail-fast: false` so one platform's failure doesn't mask the other).