### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
 
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v6.0.0
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         
     - name: Restore
       run: dotnet restore

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,4 +13,4 @@ jobs:
     name: Label
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6.2.0
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
 
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
       run: node scripts/resolve-version.mjs
 
     - name: Set up .NET
-      uses: actions/setup-dotnet@v6.0.0
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
 
     - name: Restore
       run: dotnet restore
@@ -58,7 +58,7 @@ jobs:
     - name: NuGet login
       if: ${{ !inputs.dry-run }}
       id: login
-      uses: NuGet/login@v1
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
       with:
         user: krafs
 

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -12,7 +12,7 @@ jobs:
     name: SemVer label
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const valid = ['semver:major', 'semver:minor', 'semver:patch'];


### PR DESCRIPTION
Pin all third-party action references to full commit SHAs with a version comment. The floating major tags (`github-script@v9`, `NuGet/login@v1`) were the real exposure — a compromised upstream tag would run in the release pipeline.

Dependabot's `github-actions` ecosystem understands the `# vX.Y.Z` comment convention and keeps both SHA and comment current.