### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: Scorecard
+
+on:
+  schedule:
+    - cron: '30 4 * * 1'
+  push:
+    branches: [ main ]
+
+# Read-only by default; the job below elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+    steps:
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: Run analysis
+      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      with:
+        results_file: results.sarif
+        results_format: sarif
+        publish_results: false
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: scorecard-results
+        path: results.sarif
+        retention-days: 5
+
+    - name: Upload to code scanning
+      uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+      with:
+        sarif_file: results.sarif


### PR DESCRIPTION
Add a weekly OpenSSF Scorecard run (plus on push to main) that scores the repo's supply-chain security posture and uploads results to the code-scanning tab.

`publish_results: false` — results stay private to the repo, not pushed to the public OpenSSF API. Actions pinned by SHA; job runs read-only except `security-events: write` for the SARIF upload.