### PR TITLE
Add zizmor workflow linting

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: Zizmor
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Zizmor analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+    steps:
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0


### PR DESCRIPTION
Static analysis of the GitHub Actions workflows on push to main and PRs. Findings upload to the code-scanning tab via GitHub Advanced Security (free on public repos); non-blocking, matching the Scorecard setup.

Top-level `permissions: {}`; the job elevates only `security-events: write`. Action and checkout pinned by SHA.