### PR TITLE
Tighten workflow permissions and add LICENSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Test
@@ -21,6 +24,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Set up .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -47,13 +50,17 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build -c Release --no-restore -p:Version=${{ steps.resolve.outputs.version }}
+      env:
+        VERSION: ${{ steps.resolve.outputs.version }}
+      run: dotnet build -c Release --no-restore -p:Version="$VERSION"
 
     - name: Test
       run: dotnet test -c Release --no-build --no-restore
 
     - name: Pack
-      run: dotnet pack src/Publicizer/Publicizer.csproj -c Release --no-build -p:Version=${{ steps.resolve.outputs.version }} -o artifacts
+      env:
+        VERSION: ${{ steps.resolve.outputs.version }}
+      run: dotnet pack src/Publicizer/Publicizer.csproj -c Release --no-build -p:Version="$VERSION" -o artifacts
 
     - name: NuGet login
       if: ${{ !inputs.dry-run }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Krafs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Clears the actionable code-scanning findings from the new Scorecard/zizmor runs.

- Top-level least-privilege `permissions: contents: read` on CI and Release (TokenPermissions, excessive-permissions)
- `persist-credentials: false` on the CI checkout (artipacked; Release keeps them — it pushes the tag)
- Resolved version passed via env var in Build/Pack instead of inline `${{ }}` (template-injection)
- Add a LICENSE file backing the existing MIT package metadata