### PR TITLE
Add dependency review gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: Review dependencies
+      uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0


### PR DESCRIPTION
Blocks PRs that introduce vulnerable or badly-licensed dependencies at PR time, complementing Dependabot's scheduled scans with an inbound gate.

Runs on pull_request only, with a read-only `contents: read` token — no PR comments, so it stays safe for fork PRs. Findings surface via the check status and job summary.