### PR TITLE
Attest build provenance for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
       pull-requests: read
     env:
       DOTNET_NOLOGO: true
@@ -64,6 +65,12 @@ jobs:
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
       run: dotnet pack src/Publicizer/Publicizer.csproj -c Release --no-build -p:Version="$VERSION" -o artifacts
+
+    - name: Attest build provenance
+      if: ${{ !inputs.dry-run }}
+      uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+      with:
+        subject-path: artifacts/*.nupkg
 
     - name: NuGet login
       if: ${{ !inputs.dry-run }}


### PR DESCRIPTION
Generate a signed SLSA provenance attestation for the packed `.nupkg` during a real release, tying the artifact back to the workflow that built it.

- Adds `actions/attest-build-provenance` after Pack, gated on `!dry-run`
- Grants the release job `attestations: write` (`id-token: write` already present)