### PR TITLE
Clean stale dev packages before packing

### DIFF
--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -55,4 +55,14 @@
     </ItemGroup>
   </Target>
 
+  <!-- Remove stale nupkgs so the output folder holds only the freshly built one.
+       The tests resolve Krafs.Publicizer via Version="*"; a leftover higher-versioned
+       package (e.g. a previous release) would otherwise shadow this build. -->
+  <Target Name="CleanStalePackages" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_StalePackage Include="$([MSBuild]::EnsureTrailingSlash($(PackageOutputPath)))Krafs.Publicizer.*.nupkg" />
+    </ItemGroup>
+    <Delete Files="@(_StalePackage)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
The test suite resolves `Krafs.Publicizer` via `Version="*"` against the local `bin` folder. If a higher-versioned package lingers there (a previous release tag build, a hand-dropped nupkg), `*` picks it over the freshly built one — so the tests silently exercise the wrong code. A pre-pack target now deletes stale `Krafs.Publicizer.*.nupkg` so only the current build remains.

Local-dev only; CI builds from a clean checkout and was never affected.