### PR TITLE
Invalidate cached assemblies when the Publicizer version changes

### DIFF
--- a/src/Publicizer/Hasher.cs
+++ b/src/Publicizer/Hasher.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -10,9 +11,19 @@ namespace Publicizer;
 /// </summary>
 internal static class Hasher
 {
+    // Includes the commit hash via SourceLink, so it changes on every build.
+    // Feeding it into the cache key invalidates assemblies publicized by an
+    // older Publicizer whose publicization logic may have differed.
+    private static readonly string PublicizerVersion =
+        typeof(Hasher).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+        ?? "unknown";
+
     internal static string ComputeHash(string assemblyPath, PublicizerAssemblyContext assemblyContext)
     {
         var sb = new StringBuilder();
+        sb.Append(PublicizerVersion);
         sb.Append(assemblyContext.AssemblyName);
         sb.Append(assemblyContext.IncludeCompilerGeneratedMembers);
         sb.Append(assemblyContext.IncludeVirtualMembers);


### PR DESCRIPTION
The publicization cache hash omitted the Publicizer version, so a newer Publicizer could silently reuse an assembly an older one produced under different logic. The SourceLink-stamped informational version (which carries the commit hash) now feeds the hash, so any Publicizer change invalidates stale cached assemblies.

In practice this means anyone upgrading gets their publicized assemblies rebuilt on the first build after the upgrade, rather than silently keeping output from the previous version — which matters here because #200 changes what publicization produces.

A minimal guard to land with the nested-type fix (#200); the full hashing redesign is deferred to the engine rewrite. Not unit-tested — the hash is internal and there's no in-process test layer yet.