### PR TITLE
Remove dead NoWarn NU1702 in test project

### DIFF
--- a/src/Publicizer.Tests/Publicizer.Tests.csproj
+++ b/src/Publicizer.Tests/Publicizer.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <NoWarn>NU1702</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The netstandard2.0 retarget (#202) made the test project's ProjectReference to Publicizer compatible, so NU1702 no longer fires. The suppression is dead config — removed (verified: 0 warnings).