### PR TITLE
Clean stale nupkgs from test project output

### DIFF
--- a/src/Publicizer.Tests/Publicizer.Tests.csproj
+++ b/src/Publicizer.Tests/Publicizer.Tests.csproj
@@ -19,7 +19,9 @@
   <Target Name="CopyNugetPackage" AfterTargets="AfterBuild">
     <ItemGroup>
       <PublicizerNuget Include="..\Publicizer\bin\Krafs.Publicizer.*.nupkg"  />
+      <StaleNuget Include="$(OutputPath)Krafs.Publicizer.*.nupkg" />
     </ItemGroup>
+    <Delete Files="@(StaleNuget)" />
     <Copy SourceFiles="@(PublicizerNuget)" DestinationFolder="$(OutputPath)" />
   </Target>
 


### PR DESCRIPTION
Follow-up to #199 (which cleans only the pack output). `CopyNugetPackage` copied the freshly built package into `Publicizer.Tests/bin` but nothing cleaned the destination — a lingering higher-versioned copy shadowed it under `Version="*"`, silently running the suite against the wrong code. Now deletes stale `Krafs.Publicizer.*.nupkg` in the destination before copying. Local-dev only; CI uses a clean checkout.