### PR TITLE
Extract a builder for e2e consumer projects

### DIFF
--- a/src/Publicizer.E2ETests/PublicizerTests.cs
+++ b/src/Publicizer.E2ETests/PublicizerTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using NUnit.Framework;
 
 namespace Publicizer.E2ETests;
@@ -11,7 +10,20 @@ namespace Publicizer.E2ETests;
 [Parallelizable(ParallelScope.Children)]
 public class PublicizerTests
 {
-    private const string TestTargetFramework = "net10.0";
+    private const string PrivateClassCode = """
+        namespace {0};
+        class PrivateClass
+        {
+            private PrivateClass()
+            { }
+
+            private string PrivateField = "foo";
+            private string PrivateProperty => "ba";
+            private string PrivateMethod() => "r";
+        }
+        """;
+
+    internal static string PrivateClassIn(string @namespace) => PrivateClassCode.Replace("{0}", @namespace, StringComparison.Ordinal);
 
     // Fail rather than skip: the builder is set explicitly per CI leg, so a mismatch is a
     // misconfiguration, and a silent skip would let the desktop MSBuild leg stop running
@@ -28,45 +40,8 @@ public class PublicizerTests
     [Test]
     public void PublicizeAssembly_CompilesAndRunsWithExitCode0AndPrintsReturnValuesFromAllPrivateMembersInPrivateClass()
     {
-        using var libraryFolder = new TemporaryFolder();
-        string libraryCodePath = Path.Combine(libraryFolder.Path, "PrivateClass.cs");
-        string libraryCode = """
-            namespace PrivateNamespace;
-            class PrivateClass
-            {
-                private PrivateClass()
-                { }
+        using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassIn("PrivateNamespace")).BuildOrFail();
 
-                private string PrivateField = "foo";
-                private string PrivateProperty => "ba";
-                private string PrivateMethod() => "r";
-            }
-            """;
-        File.WriteAllText(libraryCodePath, libraryCode);
-
-        string libraryCsprojPath = Path.Combine(libraryFolder.Path, "PrivateAssembly.csproj");
-        string libraryCsproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
-
-              <PropertyGroup>
-                <TargetFramework>{TestTargetFramework}</TargetFramework>
-                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                <OutDir>{libraryFolder.Path}</OutDir>
-              </PropertyGroup>
-
-              <ItemGroup>
-                <Compile Include="{libraryCodePath}" />
-              </ItemGroup>
-
-            </Project>
-            """;
-
-        File.WriteAllText(libraryCsprojPath, libraryCsproj);
-        ProcessResult buildLibraryResult = Runner.Build(libraryCsprojPath);
-        Assert.That(buildLibraryResult.ExitCode, Is.Zero, buildLibraryResult.Output);
-
-        using var appFolder = new TemporaryFolder();
-        string appCodePath = Path.Combine(appFolder.Path, "Program.cs");
         string appCode = """
             var privateClass = new PrivateNamespace.PrivateClass();
             var result = privateClass.PrivateField;
@@ -74,121 +49,26 @@ public class PublicizerTests
             result += privateClass.PrivateMethod();
             System.Console.Write(result);
             """;
-        File.WriteAllText(appCodePath, appCode);
-        string libraryPath = Path.Combine(libraryFolder.Path, "PrivateAssembly.dll");
 
-        string appCsproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
+        using TestProject app = TestProject.App(appCode)
+            .Referencing(library)
+            .ConsumingPublicizer()
+            .Item("Publicize", "PrivateAssembly");
 
-              <PropertyGroup>
-                <TargetFramework>{TestTargetFramework}</TargetFramework>
-                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                <OutputType>exe</OutputType>
-                <OutDir>{appFolder.Path}</OutDir>
-              </PropertyGroup>
+        ProcessResult buildResult = app.Build();
+        ProcessResult runResult = app.Run();
 
-              <ItemGroup>
-                <Compile Include="{appCodePath}" />
-                <Reference Include="PrivateAssembly" HintPath="{libraryPath}" />
-                <PackageReference Include="Krafs.Publicizer" Version="*" />
-                <Publicize Include="PrivateAssembly" />
-              </ItemGroup>
-
-            </Project>
-            """;
-
-        string appCsprojPath = Path.Combine(appFolder.Path, "App.csproj");
-        File.WriteAllText(appCsprojPath, appCsproj);
-        string appPath = Path.Combine(appFolder.Path, "App.dll");
-        NugetConfigMaker.CreateConfigThatRestoresPublicizerLocally(appFolder.Path);
-
-        ProcessResult buildAppProcess = Runner.Build(appCsprojPath);
-        ProcessResult runAppProcess = Runner.Run("dotnet", appPath);
-
-        Assert.That(buildAppProcess.ExitCode, Is.Zero, buildAppProcess.Output);
-        Assert.That(runAppProcess.ExitCode, Is.Zero, runAppProcess.Output);
-        Assert.That(runAppProcess.Output, Is.EqualTo("foobar"), runAppProcess.Output);
+        Assert.That(buildResult.ExitCode, Is.Zero, buildResult.Output);
+        Assert.That(runResult.ExitCode, Is.Zero, runResult.Output);
+        Assert.That(runResult.Output, Is.EqualTo("foobar"), runResult.Output);
     }
 
     [Test]
     public void PublicizeAll_CompilesAndRunsWithExitCode0AndPrintsReturnValuesFromPrivateMembersFromTwoDifferentAssemblies()
     {
-        using var library1Folder = new TemporaryFolder();
-        string library1CodePath = Path.Combine(library1Folder.Path, "PrivateClass.cs");
-        string library1Code = """
-            namespace PrivateNamespace1;
-            class PrivateClass
-            {
-                private PrivateClass()
-                { }
+        using TestProject library1 = TestProject.Library("PrivateAssembly1", PrivateClassIn("PrivateNamespace1")).BuildOrFail();
+        using TestProject library2 = TestProject.Library("PrivateAssembly2", PrivateClassIn("PrivateNamespace2")).BuildOrFail();
 
-                private string PrivateField = "foo";
-                private string PrivateProperty => "ba";
-                private string PrivateMethod() => "r";
-            }
-            """;
-        File.WriteAllText(library1CodePath, library1Code);
-
-        string library1CsprojPath = Path.Combine(library1Folder.Path, "PrivateAssembly1.csproj");
-        string library1Csproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
-
-              <PropertyGroup>
-                <TargetFramework>{TestTargetFramework}</TargetFramework>
-                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                <OutDir>{library1Folder.Path}</OutDir>
-              </PropertyGroup>
-
-              <ItemGroup>
-                <Compile Include="{library1CodePath}" />
-              </ItemGroup>
-
-            </Project>
-            """;
-
-        File.WriteAllText(library1CsprojPath, library1Csproj);
-        ProcessResult buildLibrary1Result = Runner.Build(library1CsprojPath);
-        Assert.That(buildLibrary1Result.ExitCode, Is.Zero, buildLibrary1Result.Output);
-
-        using var library2Folder = new TemporaryFolder();
-        string library2CodePath = Path.Combine(library2Folder.Path, "PrivateClass.cs");
-        string library2Code = """
-            namespace PrivateNamespace2;
-            class PrivateClass
-            {
-                private PrivateClass()
-                { }
-
-                private string PrivateField = "foo";
-                private string PrivateProperty => "ba";
-                private string PrivateMethod() => "r";
-            }
-            """;
-        File.WriteAllText(library2CodePath, library2Code);
-
-        string library2CsprojPath = Path.Combine(library2Folder.Path, "PrivateAssembly2.csproj");
-        string library2Csproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
-
-              <PropertyGroup>
-                <TargetFramework>{TestTargetFramework}</TargetFramework>
-                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                <OutDir>{library2Folder.Path}</OutDir>
-              </PropertyGroup>
-
-              <ItemGroup>
-                <Compile Include="{library2CodePath}" />
-              </ItemGroup>
-
-            </Project>
-            """;
-
-        File.WriteAllText(library2CsprojPath, library2Csproj);
-        ProcessResult buildLibrary2Result = Runner.Build(library2CsprojPath);
-        Assert.That(buildLibrary2Result.ExitCode, Is.Zero, buildLibrary2Result.Output);
-
-        using var appFolder = new TemporaryFolder();
-        string appCodePath = Path.Combine(appFolder.Path, "Program.cs");
         string appCode = """
             var privateClass1 = new PrivateNamespace1.PrivateClass();
             var result1 = privateClass1.PrivateField;
@@ -202,41 +82,18 @@ public class PublicizerTests
 
             System.Console.Write(result1 + result2);
             """;
-        File.WriteAllText(appCodePath, appCode);
-        string library1Path = Path.Combine(library1Folder.Path, "PrivateAssembly1.dll");
-        string library2Path = Path.Combine(library2Folder.Path, "PrivateAssembly2.dll");
 
-        string appCsproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
+        using TestProject app = TestProject.App(appCode)
+            .Referencing(library1)
+            .Referencing(library2)
+            .ConsumingPublicizer()
+            .Property("PublicizeAll", "true");
 
-              <PropertyGroup>
-                <TargetFramework>{TestTargetFramework}</TargetFramework>
-                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                <OutputType>exe</OutputType>
-                <OutDir>{appFolder.Path}</OutDir>
-                <PublicizeAll>true</PublicizeAll>
-              </PropertyGroup>
+        ProcessResult buildResult = app.Build();
+        ProcessResult runResult = app.Run();
 
-              <ItemGroup>
-                <Compile Include="{appCodePath}" />
-                <Reference Include="PrivateAssembly1" HintPath="{library1Path}" />
-                <Reference Include="PrivateAssembly2" HintPath="{library2Path}" />
-                <PackageReference Include="Krafs.Publicizer" Version="*" />
-              </ItemGroup>
-
-            </Project>
-            """;
-
-        string appCsprojPath = Path.Combine(appFolder.Path, "App.csproj");
-        File.WriteAllText(appCsprojPath, appCsproj);
-        string appPath = Path.Combine(appFolder.Path, "App.dll");
-        NugetConfigMaker.CreateConfigThatRestoresPublicizerLocally(appFolder.Path);
-
-        ProcessResult buildAppProcess = Runner.Build(appCsprojPath);
-        ProcessResult runAppProcess = Runner.Run("dotnet", appPath);
-
-        Assert.That(buildAppProcess.ExitCode, Is.Zero, buildAppProcess.Output);
-        Assert.That(runAppProcess.ExitCode, Is.Zero, runAppProcess.Output);
-        Assert.That(runAppProcess.Output, Is.EqualTo("foobarfoobar"), runAppProcess.Output);
+        Assert.That(buildResult.ExitCode, Is.Zero, buildResult.Output);
+        Assert.That(runResult.ExitCode, Is.Zero, runResult.Output);
+        Assert.That(runResult.Output, Is.EqualTo("foobarfoobar"), runResult.Output);
     }
 }

--- a/src/Publicizer.E2ETests/TestProject.cs
+++ b/src/Publicizer.E2ETests/TestProject.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Publicizer.E2ETests;
+
+// A throwaway consumer project in a temporary folder: one source file, a csproj assembled
+// from the properties and items a test adds, and the build/run of it. Each project builds
+// into its own folder, so tests reference each other's output by path.
+internal sealed class TestProject : IDisposable
+{
+    internal const string DefaultTargetFramework = "net10.0";
+
+    private readonly TemporaryFolder _folder = new();
+    private readonly string _name;
+    private readonly string _outputType;
+    private readonly string _sourcePath;
+    private readonly List<string> _properties = [];
+    private readonly List<string> _items = [];
+
+    private TestProject(string name, string outputType, string sourceCode)
+    {
+        _name = name;
+        _outputType = outputType;
+        _sourcePath = Path.Combine(_folder.Path, "Source.cs");
+        File.WriteAllText(_sourcePath, sourceCode);
+    }
+
+    internal static TestProject Library(string name, string sourceCode) => new(name, "library", sourceCode);
+
+    internal static TestProject App(string sourceCode) => new("App", "exe", sourceCode);
+
+    internal string Folder => _folder.Path;
+
+    internal string AssemblyPath => Path.Combine(_folder.Path, $"{_name}.dll");
+
+    internal string ProjectPath => Path.Combine(_folder.Path, $"{_name}.csproj");
+
+    internal TestProject Property(string name, string value)
+    {
+        _properties.Add($"<{name}>{value}</{name}>");
+        return this;
+    }
+
+    internal TestProject Item(string type, string include, string? attributes = null)
+    {
+        _items.Add($"""<{type} Include="{include}"{(attributes is null ? "" : " " + attributes)} />""");
+        return this;
+    }
+
+    internal TestProject Referencing(TestProject other) => Item("Reference", other._name, $"""HintPath="{other.AssemblyPath}" """);
+
+    // The PackageReference plus the nuget.config that resolves it from the locally packed nupkg.
+    internal TestProject ConsumingPublicizer()
+    {
+        NugetConfigMaker.CreateConfigThatRestoresPublicizerLocally(_folder.Path);
+        return Item("PackageReference", "Krafs.Publicizer", """Version="*" """);
+    }
+
+    internal ProcessResult Build(params string[] extraArguments)
+    {
+        File.WriteAllText(ProjectPath, ToCsproj());
+        return Runner.Build(ProjectPath, extraArguments);
+    }
+
+    // For the setup steps a test isn't itself about: a failure here is a broken fixture, not a finding.
+    internal TestProject BuildOrFail()
+    {
+        ProcessResult result = Build();
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Building {_name} failed with exit code {result.ExitCode}:{Environment.NewLine}{result.Output}{result.Error}");
+        }
+        return this;
+    }
+
+    internal ProcessResult Run() => Runner.Run("dotnet", AssemblyPath);
+
+    private string ToCsproj()
+    {
+        string properties = string.Join(Environment.NewLine + "    ", _properties);
+        string items = string.Join(Environment.NewLine + "    ", _items);
+
+        return $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+
+              <PropertyGroup>
+                <TargetFramework>{DefaultTargetFramework}</TargetFramework>
+                <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+                <OutputType>{_outputType}</OutputType>
+                <OutDir>{_folder.Path}</OutDir>
+                {properties}
+              </PropertyGroup>
+
+              <ItemGroup>
+                <Compile Include="{_sourcePath}" />
+                {items}
+              </ItemGroup>
+
+            </Project>
+            """;
+    }
+
+    public void Dispose() => ((IDisposable)_folder).Dispose();
+}


### PR DESCRIPTION
Pure refactor of the end-to-end tests: the inline csproj XML moves behind a small `TestProject` builder. No change to what is asserted.

Stacked on #211 — the scenarios queued behind this (design-time builds, rebuild/incremental, a .NET Framework consumer) each vary one knob of the same setup, which the copy-pasted form made expensive.