### PR TITLE
Cover design-time builds in e2e tests

### DIFF
--- a/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
+++ b/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace Publicizer.E2ETests;
+
+// Visual Studio drives IntelliSense from design-time builds: ResolveReferences only, no
+// compiler invocation, with DesignTimeBuild set. If publicization doesn't happen there, the
+// editor resolves the original assembly and marks every non-public member as inaccessible —
+// red squiggles over code that compiles fine from the command line. Nothing else in the
+// suite runs a build in that mode.
+[Parallelizable(ParallelScope.Children)]
+public class DesignTimeBuildTests
+{
+    // The properties the .NET Project System sets for a design-time build.
+    private static readonly string[] DesignTimeBuildArguments =
+    [
+        "-t:DumpReferencePaths",
+        "-p:DesignTimeBuild=true",
+        "-p:SkipCompilerExecution=true",
+        "-p:ProvideCommandLineArgs=true",
+        "-p:DesignTimeSilentResolution=true"
+    ];
+
+    // ResolveReferences is what the design-time targets depend on, and where Publicizer
+    // swaps the reference; dumping ReferencePath afterwards is how we see what the editor
+    // would have been handed.
+    private const string DumpTarget = """
+          <Target Name="DumpReferencePaths" DependsOnTargets="ResolveReferences">
+            <WriteLinesToFile File="$(MSBuildProjectDirectory)/referencepaths.txt" Lines="@(ReferencePath)" Overwrite="true" WriteOnlyWhenDifferent="false" />
+          </Target>
+        """;
+
+    [Test]
+    public void DesignTimeBuild_ResolvesThePublicizedAssemblyRatherThanTheOriginal()
+    {
+        using TestProject library = TestProject.Library("PrivateAssembly", PublicizerTests.PrivateClassIn("PrivateNamespace")).BuildOrFail();
+
+        using TestProject app = TestProject.App("System.Console.Write(new PrivateNamespace.PrivateClass().PrivateField);")
+            .Referencing(library)
+            .ConsumingPublicizer()
+            .Item("Publicize", "PrivateAssembly")
+            .RawXml(DumpTarget);
+
+        ProcessResult result = app.Build(DesignTimeBuildArguments);
+        Assert.That(result.ExitCode, Is.Zero, result.Output);
+
+        string[] referencePaths = File.ReadAllLines(Path.Combine(app.Folder, "referencepaths.txt"));
+        string[] privateAssemblyPaths = Array.FindAll(referencePaths, path => path.EndsWith("PrivateAssembly.dll", StringComparison.OrdinalIgnoreCase));
+
+        Assert.That(privateAssemblyPaths, Has.Length.EqualTo(1), result.Output);
+        Assert.That(privateAssemblyPaths[0], Does.Contain("PublicizedAssemblies"), result.Output);
+    }
+}

--- a/src/Publicizer.E2ETests/TestProject.cs
+++ b/src/Publicizer.E2ETests/TestProject.cs
@@ -17,6 +17,7 @@ internal sealed class TestProject : IDisposable
     private readonly string _sourcePath;
     private readonly List<string> _properties = [];
     private readonly List<string> _items = [];
+    private readonly List<string> _rawXml = [];
 
     private TestProject(string name, string outputType, string sourceCode)
     {
@@ -57,6 +58,13 @@ internal sealed class TestProject : IDisposable
         return Item("PackageReference", "Krafs.Publicizer", """Version="*" """);
     }
 
+    // Raw XML appended inside the project, for the odd test that needs a target of its own.
+    internal TestProject RawXml(string xml)
+    {
+        _rawXml.Add(xml);
+        return this;
+    }
+
     internal ProcessResult Build(params string[] extraArguments)
     {
         File.WriteAllText(ProjectPath, ToCsproj());
@@ -80,6 +88,7 @@ internal sealed class TestProject : IDisposable
     {
         string properties = string.Join(Environment.NewLine + "    ", _properties);
         string items = string.Join(Environment.NewLine + "    ", _items);
+        string rawXml = string.Join(Environment.NewLine, _rawXml);
 
         return $"""
             <Project Sdk="Microsoft.NET.Sdk">
@@ -96,6 +105,8 @@ internal sealed class TestProject : IDisposable
                 <Compile Include="{_sourcePath}" />
                 {items}
               </ItemGroup>
+
+              {rawXml}
 
             </Project>
             """;


### PR DESCRIPTION
Adds one case that runs `ResolveReferences` with the properties the .NET Project System sets for a design-time build and asserts the publicized assembly — not the original — is what ends up in `ReferencePath`.

This is the mode Visual Studio drives IntelliSense from, and it invokes no compiler, so a full build passing says nothing about it. The failure it guards against is red squiggles in the editor over code that compiles.

Stacked on #212.