### PR TITLE
Cover rebuilds in e2e tests

### DIFF
--- a/src/Publicizer.E2ETests/RebuildTests.cs
+++ b/src/Publicizer.E2ETests/RebuildTests.cs
@@ -1,0 +1,86 @@
+using NUnit.Framework;
+
+namespace Publicizer.E2ETests;
+
+// The rest of the suite only ever builds a consumer once, from clean. Visual Studio builds
+// the same project over and over in one session, against publicized assemblies cached in
+// the intermediate folder and against a build node that never goes away — which is where
+// stale-cache and file-locking failures live.
+[Parallelizable(ParallelScope.Children)]
+public class RebuildTests
+{
+    private const string PrivateClassPrintingFoo = """
+        namespace PrivateNamespace;
+        class PrivateClass
+        {
+            private string PrivateField = "foo";
+        }
+        """;
+
+    private const string AppCode = "System.Console.Write(new PrivateNamespace.PrivateClass().PrivateField);";
+
+    private static TestProject Consumer(TestProject library) => TestProject.App(AppCode)
+        .Referencing(library)
+        .ConsumingPublicizer()
+        .Item("Publicize", "PrivateAssembly");
+
+    [Test]
+    public void RebuildingAnUnchangedConsumer_StillBuildsAndRuns()
+    {
+        using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassPrintingFoo).BuildOrFail();
+        using TestProject app = Consumer(library);
+
+        Assert.That(app.Build().ExitCode, Is.Zero);
+
+        ProcessResult rebuildResult = app.Build();
+        ProcessResult runResult = app.Run();
+
+        Assert.That(rebuildResult.ExitCode, Is.Zero, rebuildResult.Output);
+        Assert.That(runResult.Output, Is.EqualTo("foo"), runResult.Output);
+    }
+
+    [Test]
+    public void RebuildingAfterTheReferencedAssemblyChanged_PublicizesTheNewOne()
+    {
+        using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassPrintingFoo).BuildOrFail();
+        using TestProject app = Consumer(library);
+
+        Assert.That(app.Build().ExitCode, Is.Zero);
+
+        // A new member, so the rebuilt app only compiles if the cached publicized assembly
+        // was replaced rather than reused.
+        library.Rewrite("""
+            namespace PrivateNamespace;
+            class PrivateClass
+            {
+                private string PrivateField = "foo";
+                private string PrivateMethodAddedLater() => "bar";
+            }
+            """).BuildOrFail();
+
+        app.Rewrite("System.Console.Write(new PrivateNamespace.PrivateClass().PrivateMethodAddedLater());");
+
+        ProcessResult rebuildResult = app.Build();
+        ProcessResult runResult = app.Run();
+
+        Assert.That(rebuildResult.ExitCode, Is.Zero, rebuildResult.Output);
+        Assert.That(runResult.Output, Is.EqualTo("bar"), runResult.Output);
+    }
+
+    [Test]
+    public void RebuildingThroughAReusedBuildNode_StillBuildsAndRuns()
+    {
+        using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassPrintingFoo).BuildOrFail();
+        using TestProject app = Consumer(library);
+
+        Assert.That(app.BuildReusingNodes().ExitCode, Is.Zero);
+
+        // The second build lands on the node the first one left running, with the task
+        // assembly already loaded and the publicized assembly possibly still held open.
+        ProcessResult rebuildResult = app.BuildReusingNodes();
+        ProcessResult runResult = app.Run();
+
+        Assert.That(rebuildResult.ExitCode, Is.Zero, rebuildResult.Output);
+        Assert.That(runResult.Output, Is.EqualTo("foo"), runResult.Output);
+    }
+}

--- a/src/Publicizer.E2ETests/Runner.cs
+++ b/src/Publicizer.E2ETests/Runner.cs
@@ -13,16 +13,19 @@ internal static class Runner
     internal static bool UsesDesktopMSBuild => Builder.Equals("msbuild", StringComparison.OrdinalIgnoreCase);
 
     // Extra arguments go to the host verbatim, so use only spellings both accept (-p:, -t:).
-    internal static ProcessResult Build(string projectPath, params string[] extraArguments)
+    internal static ProcessResult Build(string projectPath, params string[] extraArguments) => Build(projectPath, reuseNodes: false, extraArguments);
+
+    // reuseNodes leaves the build node alive afterwards, holding the task assembly loaded —
+    // what a Visual Studio session does between builds. Off by default so tests don't serve
+    // each other stale nodes; on for the case that is about exactly that.
+    internal static ProcessResult Build(string projectPath, bool reuseNodes, string[] extraArguments)
     {
         // -restore (not -t:restore,build): restore in a separate evaluation so the build
         // sees the NuGet-generated imports that pull in Publicizer's props/targets.
-        // -nodeReuse:false: desktop MSBuild keeps nodes alive by default, which would let one
-        // test's node serve another with a task assembly already loaded. Core MSBuild under
-        // `dotnet build` already defaults to no reuse.
+        string nodeReuse = $"-nodeReuse:{(reuseNodes ? "true" : "false")}";
         string[] arguments = UsesDesktopMSBuild
-            ? ["-nologo", "-v:m", "-nodeReuse:false", projectPath, "-restore", .. extraArguments]
-            : ["build", "-nologo", "-v:m", projectPath, .. extraArguments];
+            ? ["-nologo", "-v:m", nodeReuse, projectPath, "-restore", .. extraArguments]
+            : ["build", "-nologo", "-v:m", nodeReuse, projectPath, .. extraArguments];
 
         return Run(UsesDesktopMSBuild ? "msbuild" : "dotnet", arguments);
     }

--- a/src/Publicizer.E2ETests/TestProject.cs
+++ b/src/Publicizer.E2ETests/TestProject.cs
@@ -33,7 +33,13 @@ internal sealed class TestProject : IDisposable
 
     internal string Folder => _folder.Path;
 
-    internal string AssemblyPath => Path.Combine(_folder.Path, $"{_name}.dll");
+    // Output goes to a subfolder, not the project directory: with the two the same, a
+    // consumer's copy-local of a reference lands next to its own project and gets resolved
+    // in preference to the HintPath on the next build — stale, and nothing to do with the
+    // code under test.
+    private string OutputFolder => Path.Combine(_folder.Path, "bin");
+
+    internal string AssemblyPath => Path.Combine(OutputFolder, $"{_name}.dll");
 
     internal string ProjectPath => Path.Combine(_folder.Path, $"{_name}.csproj");
 
@@ -71,6 +77,19 @@ internal sealed class TestProject : IDisposable
         return Runner.Build(ProjectPath, extraArguments);
     }
 
+    // Builds through a node that stays alive afterwards, as a Visual Studio session does.
+    internal ProcessResult BuildReusingNodes()
+    {
+        File.WriteAllText(ProjectPath, ToCsproj());
+        return Runner.Build(ProjectPath, reuseNodes: true, []);
+    }
+
+    internal TestProject Rewrite(string sourceCode)
+    {
+        File.WriteAllText(_sourcePath, sourceCode);
+        return this;
+    }
+
     // For the setup steps a test isn't itself about: a failure here is a broken fixture, not a finding.
     internal TestProject BuildOrFail()
     {
@@ -97,7 +116,7 @@ internal sealed class TestProject : IDisposable
                 <TargetFramework>{DefaultTargetFramework}</TargetFramework>
                 <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
                 <OutputType>{_outputType}</OutputType>
-                <OutDir>{_folder.Path}</OutDir>
+                <OutDir>{OutputFolder}</OutDir>
                 {properties}
               </PropertyGroup>
 


### PR DESCRIPTION
Three cases for the incremental path: rebuilding an unchanged consumer, rebuilding after the referenced assembly gained a member (the publicized-assembly cache must invalidate), and rebuilding through an MSBuild node left alive between builds, as a Visual Studio session does.

Also moves test project output into a `bin` subfolder. With `OutDir` equal to the project directory, the consumer's copy-local of the reference sat next to its own project and won resolution over the `HintPath` on the second build — the rebuild test failed against a stale assembly for reasons that had nothing to do with Publicizer.

Stacked on #213.