### PR TITLE
Cover a .NET Framework consumer in e2e tests

### DIFF
--- a/src/Publicizer.E2ETests/NetFrameworkConsumerTests.cs
+++ b/src/Publicizer.E2ETests/NetFrameworkConsumerTests.cs
@@ -1,0 +1,69 @@
+using System;
+using NUnit.Framework;
+
+namespace Publicizer.E2ETests;
+
+// Every other consumer in the suite targets .NET. A .NET Framework consumer resolves
+// references through different search paths and reference assemblies, and gets the
+// IgnoresAccessChecksTo attribute compiled against a different corlib — a path Publicizer
+// supports and nothing exercised. Windows-only: building net472 needs the targeting pack.
+[Parallelizable(ParallelScope.Children)]
+public class NetFrameworkConsumerTests
+{
+    private const string NetFrameworkTargetFramework = "net472";
+
+    [SetUp]
+    public void RequireWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore(".NET Framework targeting packs are Windows-only.");
+        }
+    }
+
+    [Test]
+    public void NetFrameworkConsumer_CompilesAndRunsAgainstAPublicizedReference()
+    {
+        string libraryCode = """
+            namespace PrivateNamespace
+            {
+                class PrivateClass
+                {
+                    private string PrivateField = "foo";
+                    private string PrivateMethod() => "bar";
+                }
+            }
+            """;
+
+        using TestProject library = TestProject.Library("PrivateAssembly", libraryCode)
+            .TargetingFramework(NetFrameworkTargetFramework)
+            .BuildOrFail();
+
+        string appCode = """
+            namespace App
+            {
+                static class Program
+                {
+                    static void Main()
+                    {
+                        var privateClass = new PrivateNamespace.PrivateClass();
+                        System.Console.Write(privateClass.PrivateField + privateClass.PrivateMethod());
+                    }
+                }
+            }
+            """;
+
+        using TestProject app = TestProject.App(appCode)
+            .TargetingFramework(NetFrameworkTargetFramework)
+            .Referencing(library)
+            .ConsumingPublicizer()
+            .Item("Publicize", "PrivateAssembly");
+
+        ProcessResult buildResult = app.Build();
+        ProcessResult runResult = app.Run();
+
+        Assert.That(buildResult.ExitCode, Is.Zero, buildResult.Output);
+        Assert.That(runResult.ExitCode, Is.Zero, runResult.Output);
+        Assert.That(runResult.Output, Is.EqualTo("foobar"), runResult.Output);
+    }
+}

--- a/src/Publicizer.E2ETests/TestProject.cs
+++ b/src/Publicizer.E2ETests/TestProject.cs
@@ -18,6 +18,7 @@ internal sealed class TestProject : IDisposable
     private readonly List<string> _properties = [];
     private readonly List<string> _items = [];
     private readonly List<string> _rawXml = [];
+    private string _targetFramework = DefaultTargetFramework;
 
     private TestProject(string name, string outputType, string sourceCode)
     {
@@ -39,9 +40,19 @@ internal sealed class TestProject : IDisposable
     // code under test.
     private string OutputFolder => Path.Combine(_folder.Path, "bin");
 
+    private bool TargetsNetFramework => _targetFramework.StartsWith("net4", StringComparison.Ordinal);
+
     internal string AssemblyPath => Path.Combine(OutputFolder, $"{_name}.dll");
 
     internal string ProjectPath => Path.Combine(_folder.Path, $"{_name}.csproj");
+
+    // .NET Framework consumers resolve references through a different set of search paths
+    // and reference assemblies than .NET ones.
+    internal TestProject TargetingFramework(string targetFramework)
+    {
+        _targetFramework = targetFramework;
+        return this;
+    }
 
     internal TestProject Property(string name, string value)
     {
@@ -101,7 +112,10 @@ internal sealed class TestProject : IDisposable
         return this;
     }
 
-    internal ProcessResult Run() => Runner.Run("dotnet", AssemblyPath);
+    // .NET Framework apps produce a runnable .exe; .NET apps are launched through the host.
+    internal ProcessResult Run() => TargetsNetFramework
+        ? Runner.Run(Path.Combine(OutputFolder, $"{_name}.exe"))
+        : Runner.Run("dotnet", AssemblyPath);
 
     private string ToCsproj()
     {
@@ -113,7 +127,7 @@ internal sealed class TestProject : IDisposable
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>{DefaultTargetFramework}</TargetFramework>
+                <TargetFramework>{_targetFramework}</TargetFramework>
                 <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
                 <OutputType>{_outputType}</OutputType>
                 <OutDir>{OutputFolder}</OutDir>


### PR DESCRIPTION
Adds a net472 consumer case. Every other consumer in the suite targets .NET; a Framework one resolves references through different search paths and reference assemblies, and compiles the generated `IgnoresAccessChecksTo` attribute against a different corlib.

Skipped off Windows (no targeting pack), so in practice only the windows/msbuild leg runs it — it is unverified on Linux, and the Windows CI leg is the first real execution.

Stacked on #214.