### PR TITLE
Run e2e fixtures in parallel with each other

### DIFF
--- a/src/Publicizer.E2ETests/AssemblyInfo.cs
+++ b/src/Publicizer.E2ETests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using NUnit.Framework;
+
+// Every test here is an out-of-process build in its own temporary folder, so nothing shares
+// state and everything can run at once. ParallelScope.All rather than Children: it makes the
+// fixtures parallelizable with each other, not just the tests within one.
+[assembly: Parallelizable(ParallelScope.All)]

--- a/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
+++ b/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
@@ -9,7 +9,6 @@ namespace Publicizer.E2ETests;
 // editor resolves the original assembly and marks every non-public member as inaccessible —
 // red squiggles over code that compiles fine from the command line. Nothing else in the
 // suite runs a build in that mode.
-[Parallelizable(ParallelScope.Children)]
 public class DesignTimeBuildTests
 {
     // The properties the .NET Project System sets for a design-time build.

--- a/src/Publicizer.E2ETests/NetFrameworkConsumerTests.cs
+++ b/src/Publicizer.E2ETests/NetFrameworkConsumerTests.cs
@@ -7,7 +7,6 @@ namespace Publicizer.E2ETests;
 // references through different search paths and reference assemblies, and gets the
 // IgnoresAccessChecksTo attribute compiled against a different corlib — a path Publicizer
 // supports and nothing exercised. Windows-only: building net472 needs the targeting pack.
-[Parallelizable(ParallelScope.Children)]
 public class NetFrameworkConsumerTests
 {
     private const string NetFrameworkTargetFramework = "net472";

--- a/src/Publicizer.E2ETests/PublicizerTests.cs
+++ b/src/Publicizer.E2ETests/PublicizerTests.cs
@@ -7,7 +7,6 @@ namespace Publicizer.E2ETests;
 // and a real consumer builds and runs against a publicized reference. One case per
 // MSBuild path (explicit Publicize items, and PublicizeAll). What publicization does to
 // each member kind is covered by the characterization and engine unit tests, not here.
-[Parallelizable(ParallelScope.Children)]
 public class PublicizerTests
 {
     private const string PrivateClassCode = """

--- a/src/Publicizer.E2ETests/RebuildTests.cs
+++ b/src/Publicizer.E2ETests/RebuildTests.cs
@@ -6,7 +6,6 @@ namespace Publicizer.E2ETests;
 // the same project over and over in one session, against publicized assemblies cached in
 // the intermediate folder and against a build node that never goes away — which is where
 // stale-cache and file-locking failures live.
-[Parallelizable(ParallelScope.Children)]
 public class RebuildTests
 {
     private const string PrivateClassPrintingFoo = """


### PR DESCRIPTION
Replaces the per-fixture `[Parallelizable(ParallelScope.Children)]` with a single assembly-level `[assembly: Parallelizable(ParallelScope.All)]`, so fixtures run concurrently with each other rather than only their own tests.

Safe because every test drives an out-of-process build in its own temporary folder — no shared state. Suite wall time locally: 11s to 7s, stable over repeated runs.

Stacked on #215.