### PR TITLE
Run PR checks on any target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,12 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 permissions:
   contents: read
 
+# Job names below are matched by main's required status checks. Renaming a job
+# blocks every PR until branch protection is updated to match.
 jobs:
   test:
     name: Test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   schedule:
     - cron: '30 5 * * 1'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,6 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [ main ]
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 permissions: {}
 


### PR DESCRIPTION
CI, CodeQL, zizmor and dependency-review all filtered `pull_request` to `branches: [main]`, so a PR stacked on another branch got no checks at all — the recent e2e stack was unverified until each part was rebased onto main.

Drops the branch filter on all four. `push` stays main-only.

Also notes in ci.yml that main's required status checks match on job name, so renaming a job silently blocks every PR.