### PR TITLE
Cover a PackageReference consumer in e2e tests

### DIFF
--- a/src/Publicizer.E2ETests/NugetConfigMaker.cs
+++ b/src/Publicizer.E2ETests/NugetConfigMaker.cs
@@ -1,16 +1,24 @@
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace Publicizer.E2ETests;
 
+// A local folder to restore from, and the one package id it is allowed to serve.
+internal readonly record struct LocalPackageSource(string Name, string Folder, string PackagePattern);
+
 internal static class NugetConfigMaker
 {
-    internal static void CreateConfigThatRestoresPublicizerLocally(string root)
-    {
-        // Given the built Krafs.Publicizer nuget package is located next to the Publicizer assembly.
-        string? publicizerPackagesFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+    // Given the built Krafs.Publicizer nuget package is located next to the Publicizer assembly.
+    internal static string PublicizerPackagesFolder => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
 
+    internal static void CreateConfig(string root, IEnumerable<LocalPackageSource> localSources)
+    {
         DirectoryInfo globalPackagesFolder = Directory.CreateDirectory(Path.Combine(root, ".nuget", "packages"));
+
+        string sources = string.Join("\n    ", localSources.Select(source => $"""<add key="{source.Name}" value="{source.Folder}" />"""));
+        string mappings = string.Join("\n    ", localSources.Select(source => $"""<packageSource key="{source.Name}"><package pattern="{source.PackagePattern}" /></packageSource>"""));
 
         string nugetConfig = $"""
         <?xml version="1.0" encoding="utf-8"?>
@@ -21,14 +29,12 @@ internal static class NugetConfigMaker
           </config>
           <packageSources>
             <clear />
-            <add key="publicizer" value="{publicizerPackagesFolder}" />
+            {sources}
             <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
           </packageSources>
           <packageSourceMapping>
             <clear />
-            <packageSource key="publicizer">
-              <package pattern="Krafs.Publicizer" />
-            </packageSource>
+            {mappings}
             <packageSource key="nuget.org">
               <package pattern="*" />
             </packageSource>

--- a/src/Publicizer.E2ETests/PackageReferenceTests.cs
+++ b/src/Publicizer.E2ETests/PackageReferenceTests.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+
+namespace Publicizer.E2ETests;
+
+// Every other consumer in the suite reaches the private assembly through a
+// <Reference HintPath=...>. The common real-world case is a PackageReference: the assembly
+// arrives on ReferencePath from the NuGet restore graph, carrying package metadata and
+// different copy-local semantics, and the reference Publicizer swaps in has to survive that.
+public class PackageReferenceTests
+{
+    private const string PrivateClassCode = """
+        namespace PrivateNamespace;
+        class PrivateClass
+        {
+            private string PrivateField = "foo";
+            private string PrivateMethod() => "bar";
+        }
+        """;
+
+    private const string AppCode = """
+        var privateClass = new PrivateNamespace.PrivateClass();
+        System.Console.Write(privateClass.PrivateField + privateClass.PrivateMethod());
+        """;
+
+    [Test]
+    public void PublicizeAssemblyFromAPackageReference_CompilesAndRuns()
+    {
+        using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassCode).PackOrFail();
+
+        using TestProject app = TestProject.App(AppCode)
+            .ReferencingPackage(library)
+            .ConsumingPublicizer()
+            .Item("Publicize", "PrivateAssembly");
+
+        ProcessResult buildResult = app.Build();
+        ProcessResult runResult = app.Run();
+
+        Assert.That(buildResult.ExitCode, Is.Zero, buildResult.Output);
+        Assert.That(runResult.ExitCode, Is.Zero, runResult.Output);
+        Assert.That(runResult.Output, Is.EqualTo("foobar"), runResult.Output);
+    }
+}

--- a/src/Publicizer.E2ETests/Runner.cs
+++ b/src/Publicizer.E2ETests/Runner.cs
@@ -30,6 +30,15 @@ internal static class Runner
         return Run(UsesDesktopMSBuild ? "msbuild" : "dotnet", arguments);
     }
 
+    internal static ProcessResult Pack(string projectPath)
+    {
+        string[] arguments = UsesDesktopMSBuild
+            ? ["-nologo", "-v:m", "-nodeReuse:false", projectPath, "-restore", "-t:pack"]
+            : ["pack", "-nologo", "-v:m", "-nodeReuse:false", projectPath];
+
+        return Run(UsesDesktopMSBuild ? "msbuild" : "dotnet", arguments);
+    }
+
     internal static ProcessResult Run(string command, params string[] arguments)
     {
         var startInfo = new ProcessStartInfo

--- a/src/Publicizer.E2ETests/TestProject.cs
+++ b/src/Publicizer.E2ETests/TestProject.cs
@@ -11,6 +11,10 @@ internal sealed class TestProject : IDisposable
 {
     internal const string DefaultTargetFramework = "net10.0";
 
+    // Fixed: each consumer restores into its own globally-isolated packages folder, so
+    // nothing collides across tests and the reference can be pinned exactly.
+    private const string PackageVersion = "1.0.0";
+
     private readonly TemporaryFolder _folder = new();
     private readonly string _name;
     private readonly string _outputType;
@@ -18,6 +22,7 @@ internal sealed class TestProject : IDisposable
     private readonly List<string> _properties = [];
     private readonly List<string> _items = [];
     private readonly List<string> _rawXml = [];
+    private readonly List<LocalPackageSource> _packageSources = [];
     private string _targetFramework = DefaultTargetFramework;
 
     private TestProject(string name, string outputType, string sourceCode)
@@ -41,6 +46,8 @@ internal sealed class TestProject : IDisposable
     private string OutputFolder => Path.Combine(_folder.Path, "bin");
 
     private bool TargetsNetFramework => _targetFramework.StartsWith("net4", StringComparison.Ordinal);
+
+    private string PackageFolder => Path.Combine(_folder.Path, "package");
 
     internal string AssemblyPath => Path.Combine(OutputFolder, $"{_name}.dll");
 
@@ -68,11 +75,20 @@ internal sealed class TestProject : IDisposable
 
     internal TestProject Referencing(TestProject other) => Item("Reference", other._name, $"""HintPath="{other.AssemblyPath}" """);
 
-    // The PackageReference plus the nuget.config that resolves it from the locally packed nupkg.
+    // The PackageReference plus the local source that resolves it from the locally packed nupkg.
     internal TestProject ConsumingPublicizer()
     {
-        NugetConfigMaker.CreateConfigThatRestoresPublicizerLocally(_folder.Path);
+        _packageSources.Add(new LocalPackageSource("publicizer", NugetConfigMaker.PublicizerPackagesFolder, "Krafs.Publicizer"));
         return Item("PackageReference", "Krafs.Publicizer", """Version="*" """);
+    }
+
+    // Consume another test project the way most real consumers do: as a package, so its
+    // assembly arrives on ReferencePath through NuGet rather than a HintPath. Requires the
+    // other project to have been packed.
+    internal TestProject ReferencingPackage(TestProject other)
+    {
+        _packageSources.Add(new LocalPackageSource(other._name, other.PackageFolder, other._name));
+        return Item("PackageReference", other._name, $"""Version="{PackageVersion}" """);
     }
 
     // Raw XML appended inside the project, for the odd test that needs a target of its own.
@@ -84,15 +100,41 @@ internal sealed class TestProject : IDisposable
 
     internal ProcessResult Build(params string[] extraArguments)
     {
-        File.WriteAllText(ProjectPath, ToCsproj());
+        Materialize();
         return Runner.Build(ProjectPath, extraArguments);
+    }
+
+    // Packs the project so another one can consume it as a PackageReference.
+    internal TestProject PackOrFail()
+    {
+        Property("PackageVersion", PackageVersion);
+        Property("PackageOutputPath", PackageFolder);
+        Materialize();
+
+        ProcessResult result = Runner.Pack(ProjectPath);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Packing {_name} failed with exit code {result.ExitCode}:{Environment.NewLine}{result.Output}{result.Error}");
+        }
+        return this;
     }
 
     // Builds through a node that stays alive afterwards, as a Visual Studio session does.
     internal ProcessResult BuildReusingNodes()
     {
-        File.WriteAllText(ProjectPath, ToCsproj());
+        Materialize();
         return Runner.Build(ProjectPath, reuseNodes: true, []);
+    }
+
+    // Written late rather than as each call comes in: the nuget.config has to list every
+    // local source at once, and sources are added one builder call at a time.
+    private void Materialize()
+    {
+        File.WriteAllText(ProjectPath, ToCsproj());
+        if (_packageSources.Count > 0)
+        {
+            NugetConfigMaker.CreateConfig(_folder.Path, _packageSources);
+        }
     }
 
     internal TestProject Rewrite(string sourceCode)


### PR DESCRIPTION
The suite only ever reached the private assembly through `<Reference HintPath=...>`. This adds a consumer that gets it from a PackageReference, so the assembly arrives on ReferencePath through the restore graph.

The library fixture is packed with `dotnet pack` into its own folder, which the consumer's nuget.config maps as a local source. nuget.config is now written at build time from a list of sources, since a consumer can need more than one.