### PR TITLE
Cover a multi-targeted consumer in e2e tests

### DIFF
--- a/src/Publicizer.E2ETests/MultiTargetedConsumerTests.cs
+++ b/src/Publicizer.E2ETests/MultiTargetedConsumerTests.cs
@@ -1,0 +1,96 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Publicizer.E2ETests;
+
+// Every other consumer in the suite has a single TargetFramework. A consumer with several
+// runs one inner build per framework, each publicizing the same reference against a
+// different corlib into its own IntermediateOutputPath — so the inner builds must neither
+// serve each other a cached assembly nor race over the same output folder.
+public class MultiTargetedConsumerTests
+{
+    private const string LegacyTargetFramework = "netstandard2.0";
+
+    private const string LibraryCode = """
+        namespace PrivateNamespace
+        {
+            class PrivateClass
+            {
+                private string PrivateField = "foo";
+            }
+        }
+        """;
+
+    // A library, not an app: netstandard2.0 has no runtime to run on, and compiling against
+    // the private member is already proof that the reference was publicized.
+    private const string ConsumerCode = """
+        namespace Consumer
+        {
+            class UsesPrivateMember
+            {
+                internal string Read() => new PrivateNamespace.PrivateClass().PrivateField;
+            }
+        }
+        """;
+
+    private static TestProject Consumer(TestProject library) => TestProject.Library("Consumer", ConsumerCode)
+        .TargetingFrameworks(LegacyTargetFramework, TestProject.DefaultTargetFramework)
+        .Referencing(library)
+        .ConsumingPublicizer()
+        .Item("Publicize", "PrivateAssembly");
+
+    [Test]
+    public void MultiTargetedConsumer_PublicizesInEveryInnerBuild()
+    {
+        using TestProject library = TestProject.Library("PrivateAssembly", LibraryCode)
+            .TargetingFramework(LegacyTargetFramework)
+            .BuildOrFail();
+
+        using TestProject consumer = Consumer(library);
+
+        ProcessResult buildResult = consumer.Build();
+
+        Assert.That(buildResult.ExitCode, Is.Zero, buildResult.Output);
+        Assert.That(File.Exists(consumer.AssemblyPathFor(LegacyTargetFramework)), Is.True, buildResult.Output);
+        Assert.That(File.Exists(consumer.AssemblyPathFor(TestProject.DefaultTargetFramework)), Is.True, buildResult.Output);
+    }
+
+    [Test]
+    public void RebuildingAMultiTargetedConsumer_PublicizesTheChangedReferenceInEveryInnerBuild()
+    {
+        using TestProject library = TestProject.Library("PrivateAssembly", LibraryCode)
+            .TargetingFramework(LegacyTargetFramework)
+            .BuildOrFail();
+
+        using TestProject consumer = Consumer(library);
+
+        Assert.That(consumer.Build().ExitCode, Is.Zero);
+
+        // A new member, so each inner build only compiles if it replaced its own cached
+        // publicized assembly rather than reusing it.
+        library.Rewrite("""
+            namespace PrivateNamespace
+            {
+                class PrivateClass
+                {
+                    private string PrivateField = "foo";
+                    private string PrivateMethodAddedLater() => "bar";
+                }
+            }
+            """).BuildOrFail();
+
+        consumer.Rewrite("""
+            namespace Consumer
+            {
+                class UsesPrivateMember
+                {
+                    internal string Read() => new PrivateNamespace.PrivateClass().PrivateMethodAddedLater();
+                }
+            }
+            """);
+
+        ProcessResult rebuildResult = consumer.Build();
+
+        Assert.That(rebuildResult.ExitCode, Is.Zero, rebuildResult.Output);
+    }
+}

--- a/src/Publicizer.E2ETests/TestProject.cs
+++ b/src/Publicizer.E2ETests/TestProject.cs
@@ -23,7 +23,7 @@ internal sealed class TestProject : IDisposable
     private readonly List<string> _items = [];
     private readonly List<string> _rawXml = [];
     private readonly List<LocalPackageSource> _packageSources = [];
-    private string _targetFramework = DefaultTargetFramework;
+    private List<string> _targetFrameworks = [DefaultTargetFramework];
 
     private TestProject(string name, string outputType, string sourceCode)
     {
@@ -45,19 +45,29 @@ internal sealed class TestProject : IDisposable
     // code under test.
     private string OutputFolder => Path.Combine(_folder.Path, "bin");
 
-    private bool TargetsNetFramework => _targetFramework.StartsWith("net4", StringComparison.Ordinal);
+    private bool IsMultiTargeted => _targetFrameworks.Count > 1;
+
+    private bool TargetsNetFramework => _targetFrameworks[0].StartsWith("net4", StringComparison.Ordinal);
 
     private string PackageFolder => Path.Combine(_folder.Path, "package");
 
-    internal string AssemblyPath => Path.Combine(OutputFolder, $"{_name}.dll");
+    internal string AssemblyPath => AssemblyPathFor(_targetFrameworks[0]);
 
     internal string ProjectPath => Path.Combine(_folder.Path, $"{_name}.csproj");
 
+    // Multi-targeted builds give each inner build its own OutDir, so an assembly is only
+    // addressable per target framework.
+    internal string AssemblyPathFor(string targetFramework) => Path.Combine(IsMultiTargeted ? Path.Combine(OutputFolder, targetFramework) : OutputFolder, $"{_name}.dll");
+
     // .NET Framework consumers resolve references through a different set of search paths
     // and reference assemblies than .NET ones.
-    internal TestProject TargetingFramework(string targetFramework)
+    internal TestProject TargetingFramework(string targetFramework) => TargetingFrameworks(targetFramework);
+
+    // More than one framework makes MSBuild run an inner build per framework, each with its
+    // own IntermediateOutputPath and its own pass over the references.
+    internal TestProject TargetingFrameworks(params string[] targetFrameworks)
     {
-        _targetFramework = targetFramework;
+        _targetFrameworks = [.. targetFrameworks];
         return this;
     }
 
@@ -165,14 +175,23 @@ internal sealed class TestProject : IDisposable
         string items = string.Join(Environment.NewLine + "    ", _items);
         string rawXml = string.Join(Environment.NewLine, _rawXml);
 
+        string targetFrameworks = IsMultiTargeted
+            ? $"<TargetFrameworks>{string.Join(";", _targetFrameworks)}</TargetFrameworks>"
+            : $"<TargetFramework>{_targetFrameworks[0]}</TargetFramework>";
+
+        // Inner builds would otherwise all write to the same OutDir and overwrite each other.
+        string outDir = IsMultiTargeted
+            ? Path.Combine(OutputFolder, "$(TargetFramework)")
+            : OutputFolder;
+
         return $"""
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                <TargetFramework>{_targetFramework}</TargetFramework>
+                {targetFrameworks}
                 <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
                 <OutputType>{_outputType}</OutputType>
-                <OutDir>{OutputFolder}</OutDir>
+                <OutDir>{outDir}</OutDir>
                 {properties}
               </PropertyGroup>
 


### PR DESCRIPTION
Every consumer in the suite so far has a single TargetFramework, so nothing exercised the inner-build-per-framework path where the same reference is publicized more than once in one build.

- `TestProject.TargetingFrameworks` emits `TargetFrameworks` and gives each inner build its own `OutDir`, which otherwise collide.
- The consumer is a library rather than an app: `netstandard2.0` has no runtime to run on, and compiling against the private member is already proof the reference was publicized.