### PR TITLE
Pin restore sources

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <!-- Clear inherited sources so a machine- or user-level nuget.config cannot introduce
+       a feed this repo never opted into. Restore resolves from nuget.org and nothing else. -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <clear />
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,18 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
-  <!-- Clear inherited sources so a machine- or user-level nuget.config cannot introduce
-       a feed this repo never opted into. Restore resolves from nuget.org and nothing else. -->
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
-
-  <packageSourceMapping>
-    <clear />
-    <packageSource key="nuget.org">
-      <package pattern="*" />
-    </packageSource>
-  </packageSourceMapping>
 
 </configuration>


### PR DESCRIPTION
Adds a repo-root `nuget.config` so restore resolves from nuget.org and nothing else, rather than inheriting whatever sources happen to be configured on the machine.

The e2e tests are unaffected — they generate their own `nuget.config` with `<clear />` in a temp folder outside the repo.

Verified `dotnet restore --locked-mode` still passes with no lock-file changes.