### PR TITLE
Make skip-changelog globs self-maintaining

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,7 @@ documentation:
 
 skip-changelog:
   - changed-files:
-      - any-glob-to-all-files:
-          - '{.github/**,.editorconfig,.gitignore,global.json,Publicizer.slnx,scripts/**,src/Publicizer.Tests/**}'
+      - all-globs-to-all-files:
+          - '!src/Publicizer/**'
+          - '!icon.png'
+          - '!**/*.md'


### PR DESCRIPTION
`skip-changelog` enumerated specific paths, so files and test projects added since (`Publicizer.E2ETests`, `Publicizer.Tests.Fixture`, `Directory.Build.props`, `Directory.Packages.props`, `nuget.config`) fell outside it and got treated as changelog-worthy.

Inverted to an exclusion list: a PR is non-user-facing unless it touches the shipped project, the package icon, or docs. New infra and test projects are covered automatically.