### PR TITLE
Collect code coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,46 @@ jobs:
       run: dotnet restore src/Publicizer.Tests/Publicizer.Tests.csproj --locked-mode
 
     - name: Test
-      run: dotnet test src/Publicizer.Tests/Publicizer.Tests.csproj -c Release --no-restore
+      run: dotnet test src/Publicizer.Tests/Publicizer.Tests.csproj -c Release --no-restore --collect "XPlat Code Coverage" --results-directory coverage
+
+    - name: Upload coverage
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: coverage
+        path: coverage/**/coverage.cobertura.xml
+
+  # Split out from Test so the pull-requests: write token isn't held while
+  # building and running test code.
+  coverage:
+    name: Coverage report
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Download coverage
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: coverage
+        path: coverage
+
+    - name: Summarize coverage
+      run: node scripts/coverage-summary.mjs coverage
+
+    # Fork PRs get a read-only token, so skip rather than fail the job.
+    - name: Comment on PR
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR: ${{ github.event.pull_request.number }}
+      run: gh pr comment "$PR" --edit-last --create-if-none --body-file coverage-summary.md
 
   e2e:
     # End-to-end tests build a real consumer and exercise the task under an MSBuild host.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,44 +36,16 @@ jobs:
     - name: Test
       run: dotnet test src/Publicizer.Tests/Publicizer.Tests.csproj -c Release --no-restore --collect "XPlat Code Coverage" --results-directory coverage
 
+    - name: Summarize coverage
+      if: ${{ !cancelled() }}
+      run: node scripts/coverage-summary.mjs coverage
+
     - name: Upload coverage
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage
         path: coverage/**/coverage.cobertura.xml
-
-  # Split out from Test so the pull-requests: write token isn't held while
-  # building and running test code.
-  coverage:
-    name: Coverage report
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-
-    - name: Download coverage
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: coverage
-        path: coverage
-
-    - name: Summarize coverage
-      run: node scripts/coverage-summary.mjs coverage
-
-    # Fork PRs get a read-only token, so skip rather than fail the job.
-    - name: Comment on PR
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
-      env:
-        GH_TOKEN: ${{ github.token }}
-        PR: ${{ github.event.pull_request.number }}
-      run: gh pr comment "$PR" --edit-last --create-if-none --body-file coverage-summary.md
 
   e2e:
     # End-to-end tests build a real consumer and exercise the task under an MSBuild host.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ obj
 .idea
 .claude
 *.received.txt
+coverage
+coverage-summary.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ obj
 .claude
 *.received.txt
 coverage
-coverage-summary.md

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="dnlib" Version="4.5.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.8.2" />

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+//
+// Summarize a Cobertura coverage report into a small Markdown table.
+//
+// Finds the first coverage.cobertura.xml under the given directory (default:
+// coverage), reads the aggregate counts from the root <coverage> element, and
+// writes coverage-summary.md. Also appends to GITHUB_STEP_SUMMARY when set so
+// the numbers show on the run page. The written file is what CI posts as a PR
+// comment.
+//
+// Numbers cover the unit tests only. The E2E suite drives the task through a
+// separate `dotnet build` process, which the in-process collector cannot see.
+//
+// Usage: node scripts/coverage-summary.mjs [coverage-dir]
+
+import { readFileSync, writeFileSync, appendFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.argv[2] ?? 'coverage';
+
+function findReport(dir) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) {
+      const found = findReport(p);
+      if (found) return found;
+    } else if (entry === 'coverage.cobertura.xml') {
+      return p;
+    }
+  }
+  return null;
+}
+
+const report = findReport(root);
+if (!report) {
+  console.error(`No coverage.cobertura.xml found under ${root}`);
+  process.exit(1);
+}
+
+const xml = readFileSync(report, 'utf8');
+const attr = (name) => {
+  const m = xml.match(new RegExp(`<coverage[^>]*\\b${name}="([^"]*)"`));
+  return m ? Number(m[1]) : NaN;
+};
+
+const pct = (covered, valid) =>
+  valid > 0 ? `${((covered / valid) * 100).toFixed(1)}% (${covered}/${valid})` : 'n/a';
+
+const md = [
+  '## Coverage',
+  '',
+  '| Metric | Coverage |',
+  '| --- | --- |',
+  `| Lines | ${pct(attr('lines-covered'), attr('lines-valid'))} |`,
+  `| Branches | ${pct(attr('branches-covered'), attr('branches-valid'))} |`,
+  '',
+  '<sub>Unit tests only — the E2E suite builds in a separate process and is not instrumented.</sub>',
+  '',
+].join('\n');
+
+writeFileSync('coverage-summary.md', md);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${md}\n`);
+}
+console.log(md);

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -4,16 +4,15 @@
 //
 // Finds the first coverage.cobertura.xml under the given directory (default:
 // coverage), reads the aggregate counts from the root <coverage> element, and
-// writes coverage-summary.md. Also appends to GITHUB_STEP_SUMMARY when set so
-// the numbers show on the run page. The written file is what CI posts as a PR
-// comment.
+// appends a table to GITHUB_STEP_SUMMARY so the numbers show on the run page.
+// Also prints to stdout so the raw job log carries them.
 //
 // Numbers cover the unit tests only. The E2E suite drives the task through a
 // separate `dotnet build` process, which the in-process collector cannot see.
 //
 // Usage: node scripts/coverage-summary.mjs [coverage-dir]
 
-import { readFileSync, writeFileSync, appendFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, appendFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 const root = process.argv[2] ?? 'coverage';
@@ -58,7 +57,6 @@ const md = [
   '',
 ].join('\n');
 
-writeFileSync('coverage-summary.md', md);
 if (process.env.GITHUB_STEP_SUMMARY) {
   appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${md}\n`);
 }

--- a/src/Publicizer.Tests/Publicizer.Tests.csproj
+++ b/src/Publicizer.Tests/Publicizer.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />

--- a/src/Publicizer.Tests/packages.lock.json
+++ b/src/Publicizer.Tests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
       "Microsoft.Build.Utilities.Core": {
         "type": "Direct",
         "requested": "[18.8.2, )",


### PR DESCRIPTION
Revives PR #197, which reported 0% because every test was end-to-end. The unit suite added since makes the number real: 94.5% lines / 94.7% branches.

- Coverage is collected from `Publicizer.Tests` only. The E2E suite shells out to a real `dotnet build`, which `XPlat Code Coverage` cannot instrument, so folding it in would drag the number to near-zero. The summary carries a footnote saying so.
- Results go to the run's step summary, not a PR comment — same table, no notifications.
- Informational only, no threshold gate. The Cobertura report is uploaded as an artifact.