### PR TITLE
Enable code analysis repo-wide

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -265,3 +265,8 @@ dotnet_diagnostic.IDE0058.severity = none
 
 # IDE0046: Convert to conditional expression
 dotnet_diagnostic.IDE0046.severity = silent
+
+# Test projects are OutputType=Exe only so the test runner can host them; they are
+# not applications, so the "make it internal" advice doesn't apply.
+[src/Publicizer{.Tests,.E2ETests}/**.cs]
+dotnet_diagnostic.CA1515.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -194,7 +194,7 @@ csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_after_semicolon_in_for_statement = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_around_declaration_statements = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_before_comma = false
 csharp_space_before_dot = false
@@ -207,7 +207,6 @@ csharp_space_between_method_call_parameter_list_parentheses = false
 csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
 csharp_space_between_method_declaration_name_and_open_parenthesis = false
 csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
 # Blocks are allowed
@@ -267,6 +266,8 @@ dotnet_diagnostic.IDE0058.severity = none
 dotnet_diagnostic.IDE0046.severity = silent
 
 # Test projects are OutputType=Exe only so the test runner can host them; they are
-# not applications, so the "make it internal" advice doesn't apply.
+# not applications, so the "make it internal" advice doesn't apply. Going internal
+# instead just trades this for CA1812 (never instantiated), since the fixtures are
+# constructed by reflection.
 [src/Publicizer{.Tests,.E2ETests}/**.cs]
 dotnet_diagnostic.CA1515.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -264,10 +264,3 @@ dotnet_diagnostic.IDE0058.severity = none
 
 # IDE0046: Convert to conditional expression
 dotnet_diagnostic.IDE0046.severity = silent
-
-# Test projects are OutputType=Exe only so the test runner can host them; they are
-# not applications, so the "make it internal" advice doesn't apply. Going internal
-# instead just trades this for CA1812 (never instantiated), since the fixtures are
-# constructed by reflection.
-[src/Publicizer{.Tests,.E2ETests}/**.cs]
-dotnet_diagnostic.CA1515.severity = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AnalysisMode>All</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!-- IDE0005 (unnecessary usings) only runs at build time when the documentation file is generated. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- CS1591: nothing here is a public API surface anyone documents against. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>

--- a/Publicizer.slnx
+++ b/Publicizer.slnx
@@ -4,6 +4,10 @@
     <File Path=".github/dependabot.yml" />
     <File Path=".github/workflows/ci.yml" />
     <File Path=".gitignore" />
+    <File Path="Directory.Build.props" />
+    <File Path="Directory.Packages.props" />
+    <File Path="global.json" />
+    <File Path="nuget.config" />
     <File Path="README.md" />
   </Folder>
   <Project Path="src/Publicizer.Tests/Publicizer.Tests.csproj" />

--- a/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
+++ b/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
@@ -7,7 +7,7 @@ namespace Publicizer.E2ETests;
 // editor resolves the original assembly and marks every non-public member as inaccessible —
 // red squiggles over code that compiles fine from the command line. Nothing else in the
 // suite runs a build in that mode.
-public class DesignTimeBuildTests
+internal static class DesignTimeBuildTests
 {
     // The properties the .NET Project System sets for a design-time build.
     private static readonly string[] s_designTimeBuildArguments =
@@ -29,7 +29,7 @@ public class DesignTimeBuildTests
         """;
 
     [Test]
-    public void DesignTimeBuild_ResolvesThePublicizedAssemblyRatherThanTheOriginal()
+    public static void DesignTimeBuild_ResolvesThePublicizedAssemblyRatherThanTheOriginal()
     {
         using TestProject library = TestProject.Library("PrivateAssembly", PublicizerTests.PrivateClassIn("PrivateNamespace")).BuildOrFail();
 

--- a/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
+++ b/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using NUnit.Framework;
 
 namespace Publicizer.E2ETests;
@@ -12,7 +10,7 @@ namespace Publicizer.E2ETests;
 public class DesignTimeBuildTests
 {
     // The properties the .NET Project System sets for a design-time build.
-    private static readonly string[] DesignTimeBuildArguments =
+    private static readonly string[] s_designTimeBuildArguments =
     [
         "-t:DumpReferencePaths",
         "-p:DesignTimeBuild=true",
@@ -41,7 +39,7 @@ public class DesignTimeBuildTests
             .Item("Publicize", "PrivateAssembly")
             .RawXml(DumpTarget);
 
-        ProcessResult result = app.Build(DesignTimeBuildArguments);
+        ProcessResult result = app.Build(s_designTimeBuildArguments);
         Assert.That(result.ExitCode, Is.Zero, result.Output);
 
         string[] referencePaths = File.ReadAllLines(Path.Combine(app.Folder, "referencepaths.txt"));

--- a/src/Publicizer.E2ETests/MultiTargetedConsumerTests.cs
+++ b/src/Publicizer.E2ETests/MultiTargetedConsumerTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using NUnit.Framework;
 
 namespace Publicizer.E2ETests;

--- a/src/Publicizer.E2ETests/MultiTargetedConsumerTests.cs
+++ b/src/Publicizer.E2ETests/MultiTargetedConsumerTests.cs
@@ -6,7 +6,7 @@ namespace Publicizer.E2ETests;
 // runs one inner build per framework, each publicizing the same reference against a
 // different corlib into its own IntermediateOutputPath — so the inner builds must neither
 // serve each other a cached assembly nor race over the same output folder.
-public class MultiTargetedConsumerTests
+internal static class MultiTargetedConsumerTests
 {
     private const string LegacyTargetFramework = "netstandard2.0";
 
@@ -39,7 +39,7 @@ public class MultiTargetedConsumerTests
         .Item("Publicize", "PrivateAssembly");
 
     [Test]
-    public void MultiTargetedConsumer_PublicizesInEveryInnerBuild()
+    public static void MultiTargetedConsumer_PublicizesInEveryInnerBuild()
     {
         using TestProject library = TestProject.Library("PrivateAssembly", LibraryCode)
             .TargetingFramework(LegacyTargetFramework)
@@ -55,7 +55,7 @@ public class MultiTargetedConsumerTests
     }
 
     [Test]
-    public void RebuildingAMultiTargetedConsumer_PublicizesTheChangedReferenceInEveryInnerBuild()
+    public static void RebuildingAMultiTargetedConsumer_PublicizesTheChangedReferenceInEveryInnerBuild()
     {
         using TestProject library = TestProject.Library("PrivateAssembly", LibraryCode)
             .TargetingFramework(LegacyTargetFramework)

--- a/src/Publicizer.E2ETests/NetFrameworkConsumerTests.cs
+++ b/src/Publicizer.E2ETests/NetFrameworkConsumerTests.cs
@@ -6,12 +6,12 @@ namespace Publicizer.E2ETests;
 // references through different search paths and reference assemblies, and gets the
 // IgnoresAccessChecksTo attribute compiled against a different corlib — a path Publicizer
 // supports and nothing exercised. Windows-only: building net472 needs the targeting pack.
-public class NetFrameworkConsumerTests
+internal static class NetFrameworkConsumerTests
 {
     private const string NetFrameworkTargetFramework = "net472";
 
     [SetUp]
-    public void RequireWindows()
+    public static void RequireWindows()
     {
         if (!OperatingSystem.IsWindows())
         {
@@ -20,7 +20,7 @@ public class NetFrameworkConsumerTests
     }
 
     [Test]
-    public void NetFrameworkConsumer_CompilesAndRunsAgainstAPublicizedReference()
+    public static void NetFrameworkConsumer_CompilesAndRunsAgainstAPublicizedReference()
     {
         string libraryCode = """
             namespace PrivateNamespace

--- a/src/Publicizer.E2ETests/NetFrameworkConsumerTests.cs
+++ b/src/Publicizer.E2ETests/NetFrameworkConsumerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using NUnit.Framework;
 
 namespace Publicizer.E2ETests;

--- a/src/Publicizer.E2ETests/NugetConfigMaker.cs
+++ b/src/Publicizer.E2ETests/NugetConfigMaker.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace Publicizer.E2ETests;

--- a/src/Publicizer.E2ETests/PackageReferenceTests.cs
+++ b/src/Publicizer.E2ETests/PackageReferenceTests.cs
@@ -6,7 +6,7 @@ namespace Publicizer.E2ETests;
 // <Reference HintPath=...>. The common real-world case is a PackageReference: the assembly
 // arrives on ReferencePath from the NuGet restore graph, carrying package metadata and
 // different copy-local semantics, and the reference Publicizer swaps in has to survive that.
-public class PackageReferenceTests
+internal static class PackageReferenceTests
 {
     private const string PrivateClassCode = """
         namespace PrivateNamespace;
@@ -23,7 +23,7 @@ public class PackageReferenceTests
         """;
 
     [Test]
-    public void PublicizeAssemblyFromAPackageReference_CompilesAndRuns()
+    public static void PublicizeAssemblyFromAPackageReference_CompilesAndRuns()
     {
         using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassCode).PackOrFail();
 

--- a/src/Publicizer.E2ETests/Publicizer.E2ETests.csproj
+++ b/src/Publicizer.E2ETests/Publicizer.E2ETests.csproj
@@ -6,24 +6,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="NUnit"/>
+    <PackageReference Include="NUnit3TestAdapter"/>
   </ItemGroup>
 
   <!-- Black-box: consume the packed nupkg, not the internals. The ProjectReference only
        forces Publicizer to build (and pack, via GeneratePackageOnBuild) before these run. -->
   <ItemGroup>
-    <ProjectReference Include="..\Publicizer\Publicizer.csproj" />
+    <ProjectReference Include="..\Publicizer\Publicizer.csproj"/>
   </ItemGroup>
 
   <Target Name="CopyNugetPackage" AfterTargets="AfterBuild">
     <ItemGroup>
-      <PublicizerNuget Include="..\Publicizer\bin\Krafs.Publicizer.*.nupkg" />
-      <StaleNuget Include="$(OutputPath)Krafs.Publicizer.*.nupkg" />
+      <PublicizerNuget Include="..\Publicizer\bin\Krafs.Publicizer.*.nupkg"/>
+      <StaleNuget Include="$(OutputPath)Krafs.Publicizer.*.nupkg"/>
     </ItemGroup>
-    <Delete Files="@(StaleNuget)" />
-    <Copy SourceFiles="@(PublicizerNuget)" DestinationFolder="$(OutputPath)" />
+    <Delete Files="@(StaleNuget)"/>
+    <Copy SourceFiles="@(PublicizerNuget)" DestinationFolder="$(OutputPath)"/>
   </Target>
 
 </Project>

--- a/src/Publicizer.E2ETests/PublicizerTests.cs
+++ b/src/Publicizer.E2ETests/PublicizerTests.cs
@@ -6,7 +6,7 @@ namespace Publicizer.E2ETests;
 // and a real consumer builds and runs against a publicized reference. One case per
 // MSBuild path (explicit Publicize items, and PublicizeAll). What publicization does to
 // each member kind is covered by the characterization and engine unit tests, not here.
-public class PublicizerTests
+internal static class PublicizerTests
 {
     private const string PrivateClassCode = """
         namespace {0};
@@ -27,7 +27,7 @@ public class PublicizerTests
     // misconfiguration, and a silent skip would let the desktop MSBuild leg stop running
     // without anyone noticing.
     [OneTimeSetUp]
-    public void RequireWindowsForDesktopMSBuild()
+    public static void RequireWindowsForDesktopMSBuild()
     {
         if (Runner.UsesDesktopMSBuild && !OperatingSystem.IsWindows())
         {
@@ -36,7 +36,7 @@ public class PublicizerTests
     }
 
     [Test]
-    public void PublicizeAssembly_CompilesAndRunsWithExitCode0AndPrintsReturnValuesFromAllPrivateMembersInPrivateClass()
+    public static void PublicizeAssembly_CompilesAndRunsWithExitCode0AndPrintsReturnValuesFromAllPrivateMembersInPrivateClass()
     {
         using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassIn("PrivateNamespace")).BuildOrFail();
 
@@ -62,7 +62,7 @@ public class PublicizerTests
     }
 
     [Test]
-    public void PublicizeAll_CompilesAndRunsWithExitCode0AndPrintsReturnValuesFromPrivateMembersFromTwoDifferentAssemblies()
+    public static void PublicizeAll_CompilesAndRunsWithExitCode0AndPrintsReturnValuesFromPrivateMembersFromTwoDifferentAssemblies()
     {
         using TestProject library1 = TestProject.Library("PrivateAssembly1", PrivateClassIn("PrivateNamespace1")).BuildOrFail();
         using TestProject library2 = TestProject.Library("PrivateAssembly2", PrivateClassIn("PrivateNamespace2")).BuildOrFail();

--- a/src/Publicizer.E2ETests/PublicizerTests.cs
+++ b/src/Publicizer.E2ETests/PublicizerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using NUnit.Framework;
 
 namespace Publicizer.E2ETests;

--- a/src/Publicizer.E2ETests/RebuildTests.cs
+++ b/src/Publicizer.E2ETests/RebuildTests.cs
@@ -6,7 +6,7 @@ namespace Publicizer.E2ETests;
 // the same project over and over in one session, against publicized assemblies cached in
 // the intermediate folder and against a build node that never goes away — which is where
 // stale-cache and file-locking failures live.
-public class RebuildTests
+internal static class RebuildTests
 {
     private const string PrivateClassPrintingFoo = """
         namespace PrivateNamespace;
@@ -24,7 +24,7 @@ public class RebuildTests
         .Item("Publicize", "PrivateAssembly");
 
     [Test]
-    public void RebuildingAnUnchangedConsumer_StillBuildsAndRuns()
+    public static void RebuildingAnUnchangedConsumer_StillBuildsAndRuns()
     {
         using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassPrintingFoo).BuildOrFail();
         using TestProject app = Consumer(library);
@@ -39,7 +39,7 @@ public class RebuildTests
     }
 
     [Test]
-    public void RebuildingAfterTheReferencedAssemblyChanged_PublicizesTheNewOne()
+    public static void RebuildingAfterTheReferencedAssemblyChanged_PublicizesTheNewOne()
     {
         using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassPrintingFoo).BuildOrFail();
         using TestProject app = Consumer(library);
@@ -67,7 +67,7 @@ public class RebuildTests
     }
 
     [Test]
-    public void RebuildingThroughAReusedBuildNode_StillBuildsAndRuns()
+    public static void RebuildingThroughAReusedBuildNode_StillBuildsAndRuns()
     {
         using TestProject library = TestProject.Library("PrivateAssembly", PrivateClassPrintingFoo).BuildOrFail();
         using TestProject app = Consumer(library);

--- a/src/Publicizer.E2ETests/Runner.cs
+++ b/src/Publicizer.E2ETests/Runner.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 
 namespace Publicizer.E2ETests;
@@ -51,13 +50,13 @@ internal static class Runner
         {
             startInfo.ArgumentList.Add(argument);
         }
-        using var process = Process.Start(startInfo)!;
+        using Process process = Process.Start(startInfo)!;
 
         // Drain both streams concurrently before waiting: a chatty child (desktop
         // msbuild -restore) can fill a pipe buffer and block on write while we block on
         // WaitForExit, deadlocking. Reading first avoids that.
-        System.Threading.Tasks.Task<string> outputTask = process.StandardOutput.ReadToEndAsync();
-        System.Threading.Tasks.Task<string> errorTask = process.StandardError.ReadToEndAsync();
+        Task<string> outputTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> errorTask = process.StandardError.ReadToEndAsync();
         process.WaitForExit();
 
         var result = new ProcessResult(

--- a/src/Publicizer.E2ETests/TemporaryFolder.cs
+++ b/src/Publicizer.E2ETests/TemporaryFolder.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-
 namespace Publicizer.E2ETests;
 
 internal sealed class TemporaryFolder : IDisposable

--- a/src/Publicizer.E2ETests/TestProject.cs
+++ b/src/Publicizer.E2ETests/TestProject.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-
 namespace Publicizer.E2ETests;
 
 // A throwaway consumer project in a temporary folder: one source file, a csproj assembled

--- a/src/Publicizer.Tests/AccessibilityManifest.cs
+++ b/src/Publicizer.Tests/AccessibilityManifest.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using dnlib.DotNet;
 

--- a/src/Publicizer.Tests/Approvals.cs
+++ b/src/Publicizer.Tests/Approvals.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using System.Runtime.CompilerServices;
 using NUnit.Framework;
 
@@ -28,7 +26,7 @@ internal static class Approvals
         string receivedPath = Path.Combine(snapshotDirectory, baseName + ".received.txt");
 
         // Normalize line endings so approved files compare equal across platforms.
-        received = received.Replace("\r\n", "\n");
+        received = received.Replace("\r\n", "\n", StringComparison.Ordinal);
 
         if (string.Equals(Environment.GetEnvironmentVariable("VERIFY_APPROVE"), "1", StringComparison.Ordinal))
         {
@@ -46,7 +44,7 @@ internal static class Approvals
             Assert.Fail($"No approved snapshot at {approvedPath}. Reviewed the received output at {receivedPath} and rename it to *.verified.txt, or re-run with VERIFY_APPROVE=1.");
         }
 
-        string approved = File.ReadAllText(approvedPath).Replace("\r\n", "\n");
+        string approved = File.ReadAllText(approvedPath).Replace("\r\n", "\n", StringComparison.Ordinal);
         if (string.Equals(approved, received, StringComparison.Ordinal))
         {
             if (File.Exists(receivedPath))

--- a/src/Publicizer.Tests/AssemblyEditorTests.cs
+++ b/src/Publicizer.Tests/AssemblyEditorTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using dnlib.DotNet;
 using NUnit.Framework;
 
@@ -96,7 +95,7 @@ public class AssemblyEditorTests
         bool modified = AssemblyEditor.PublicizeProperty(property);
 
         Assert.That(modified, Is.True);
-        Assert.That(property.GetMethod!.IsPublic, Is.True);
-        Assert.That(property.SetMethod!.IsPublic, Is.True);
+        Assert.That(property.GetMethod.IsPublic, Is.True);
+        Assert.That(property.SetMethod.IsPublic, Is.True);
     }
 }

--- a/src/Publicizer.Tests/AssemblyEditorTests.cs
+++ b/src/Publicizer.Tests/AssemblyEditorTests.cs
@@ -7,14 +7,14 @@ namespace Publicizer.Tests;
 /// Characterizes <see cref="AssemblyEditor"/>: the low-level attribute flips and
 /// their "was anything modified" return values.
 /// </summary>
-public class AssemblyEditorTests
+internal static class AssemblyEditorTests
 {
     private static TypeDef ShapesType(ModuleDef module) => module.Find("Fixture.Shapes", isReflectionName: true);
     private static FieldDef Field(ModuleDef module, string name) => ShapesType(module).Fields.Single(f => f.Name == name);
     private static MethodDef Method(ModuleDef module, string name) => ShapesType(module).Methods.Single(m => m.Name == name);
 
     [Test]
-    public void PublicizeField_PrivateField_BecomesPublicAndReturnsTrue()
+    public static void PublicizeField_PrivateField_BecomesPublicAndReturnsTrue()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         FieldDef field = Field(module, "PrivateField");
@@ -26,7 +26,7 @@ public class AssemblyEditorTests
     }
 
     [Test]
-    public void PublicizeField_AlreadyPublicField_ReturnsFalse()
+    public static void PublicizeField_AlreadyPublicField_ReturnsFalse()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         FieldDef field = Field(module, "PublicField");
@@ -38,7 +38,7 @@ public class AssemblyEditorTests
     }
 
     [Test]
-    public void PublicizeMethod_PrivateMethod_BecomesPublicAndReturnsTrue()
+    public static void PublicizeMethod_PrivateMethod_BecomesPublicAndReturnsTrue()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         MethodDef method = Method(module, "PrivateMethod");
@@ -50,7 +50,7 @@ public class AssemblyEditorTests
     }
 
     [Test]
-    public void PublicizeMethod_VirtualMethod_ExcludingVirtual_LeavesItUntouchedAndReturnsFalse()
+    public static void PublicizeMethod_VirtualMethod_ExcludingVirtual_LeavesItUntouchedAndReturnsFalse()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         MethodDef method = Method(module, "ProtectedVirtualMethod");
@@ -62,7 +62,7 @@ public class AssemblyEditorTests
     }
 
     [Test]
-    public void PublicizeMethod_VirtualMethod_IncludingVirtual_BecomesPublic()
+    public static void PublicizeMethod_VirtualMethod_IncludingVirtual_BecomesPublic()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         MethodDef method = Method(module, "ProtectedVirtualMethod");
@@ -74,7 +74,7 @@ public class AssemblyEditorTests
     }
 
     [Test]
-    public void PublicizeType_NestedType_AlsoPublicizesEnclosingType()
+    public static void PublicizeType_NestedType_AlsoPublicizesEnclosingType()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         TypeDef inner = module.Find("Fixture.Shapes+Inner", isReflectionName: true);
@@ -87,7 +87,7 @@ public class AssemblyEditorTests
     }
 
     [Test]
-    public void PublicizeProperty_PublicizesAccessorMethods()
+    public static void PublicizeProperty_PublicizesAccessorMethods()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         PropertyDef property = ShapesType(module).Properties.Single(p => p.Name == "PrivateAutoProp");

--- a/src/Publicizer.Tests/Compiler.cs
+++ b/src/Publicizer.Tests/Compiler.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;

--- a/src/Publicizer.Tests/ExecuteTests.cs
+++ b/src/Publicizer.Tests/ExecuteTests.cs
@@ -9,7 +9,7 @@ namespace Publicizer.Tests;
 /// engine. The member-level publicization behavior is covered by
 /// <see cref="PublicizeAssemblyCharacterizationTests"/>.
 /// </summary>
-public class ExecuteTests
+internal static class ExecuteTests
 {
     private static PublicizeAssemblies NewTask(string outputDirectory, out FakeBuildEngine engine)
     {
@@ -24,7 +24,7 @@ public class ExecuteTests
     }
 
     [Test]
-    public void Execute_PublicizesReference_PopulatesOutputItemsUnderOutputDirectory()
+    public static void Execute_PublicizesReference_PopulatesOutputItemsUnderOutputDirectory()
     {
         using var output = new TemporaryFolder();
         PublicizeAssemblies task = NewTask(output.Path, out _);
@@ -40,7 +40,7 @@ public class ExecuteTests
     }
 
     [Test]
-    public void Execute_SecondRunWithSameInputs_IsCacheHit()
+    public static void Execute_SecondRunWithSameInputs_IsCacheHit()
     {
         using var output = new TemporaryFolder();
 
@@ -57,7 +57,7 @@ public class ExecuteTests
     }
 
     [Test]
-    public void Execute_NoPublicizes_ReturnsTrueWithoutOutputs()
+    public static void Execute_NoPublicizes_ReturnsTrueWithoutOutputs()
     {
         using var output = new TemporaryFolder();
         var task = new PublicizeAssemblies
@@ -75,7 +75,7 @@ public class ExecuteTests
     }
 
     [Test]
-    public void Execute_PublicizeTargetMatchesNothing_WarnsAndDoesNotSwapReference()
+    public static void Execute_PublicizeTargetMatchesNothing_WarnsAndDoesNotSwapReference()
     {
         using var output = new TemporaryFolder();
         var engine = new FakeBuildEngine();
@@ -96,7 +96,7 @@ public class ExecuteTests
     }
 
     [Test]
-    public void Execute_WithLogFilePath_WritesLogFile()
+    public static void Execute_WithLogFilePath_WritesLogFile()
     {
         using var output = new TemporaryFolder();
         string logFilePath = Path.Combine(output.Path, "publicizer.log");

--- a/src/Publicizer.Tests/ExecuteTests.cs
+++ b/src/Publicizer.Tests/ExecuteTests.cs
@@ -1,6 +1,3 @@
-using System.IO;
-using System.Linq;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
 

--- a/src/Publicizer.Tests/FakeBuildEngine.cs
+++ b/src/Publicizer.Tests/FakeBuildEngine.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using Microsoft.Build.Framework;
 
 namespace Publicizer.Tests;

--- a/src/Publicizer.Tests/Fixtures.cs
+++ b/src/Publicizer.Tests/Fixtures.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using dnlib.DotNet;
 
 namespace Publicizer.Tests;

--- a/src/Publicizer.Tests/GetPublicizerAssemblyContextsTests.cs
+++ b/src/Publicizer.Tests/GetPublicizerAssemblyContextsTests.cs
@@ -9,7 +9,7 @@ namespace Publicizer.Tests;
 /// how Publicize / DoNotPublicize item specs and metadata parse into per-assembly
 /// contexts.
 /// </summary>
-public class GetPublicizerAssemblyContextsTests
+internal static class GetPublicizerAssemblyContextsTests
 {
     private static Dictionary<string, PublicizerAssemblyContext> Build(ITaskItem[] publicizes, ITaskItem[]? doNotPublicizes = null)
     {
@@ -17,7 +17,7 @@ public class GetPublicizerAssemblyContextsTests
     }
 
     [Test]
-    public void AssemblyWidePublicize_SetsExplicitlyPublicizeAssemblyWithDefaults()
+    public static void AssemblyWidePublicize_SetsExplicitlyPublicizeAssemblyWithDefaults()
     {
         Dictionary<string, PublicizerAssemblyContext> contexts = Build([new TaskItem("Asm")]);
 
@@ -30,7 +30,7 @@ public class GetPublicizerAssemblyContextsTests
     }
 
     [Test]
-    public void MemberPublicize_AddsMemberPatternAndDoesNotPublicizeWholeAssembly()
+    public static void MemberPublicize_AddsMemberPatternAndDoesNotPublicizeWholeAssembly()
     {
         Dictionary<string, PublicizerAssemblyContext> contexts =
             Build([new TaskItem("Asm:Ns.Type.Member")]);
@@ -41,7 +41,7 @@ public class GetPublicizerAssemblyContextsTests
     }
 
     [Test]
-    public void AssemblyWidePublicize_HonorsIncludeFlagMetadata()
+    public static void AssemblyWidePublicize_HonorsIncludeFlagMetadata()
     {
         var item = new TaskItem("Asm");
         item.SetMetadata("IncludeVirtualMembers", "false");
@@ -54,7 +54,7 @@ public class GetPublicizerAssemblyContextsTests
     }
 
     [Test]
-    public void AssemblyWidePublicize_HonorsMemberPatternMetadata()
+    public static void AssemblyWidePublicize_HonorsMemberPatternMetadata()
     {
         var item = new TaskItem("Asm");
         item.SetMetadata("MemberPattern", ".*Foo.*");
@@ -65,7 +65,7 @@ public class GetPublicizerAssemblyContextsTests
     }
 
     [Test]
-    public void DoNotPublicizeAssembly_SetsExplicitlyDoNotPublicizeAssembly()
+    public static void DoNotPublicizeAssembly_SetsExplicitlyDoNotPublicizeAssembly()
     {
         Dictionary<string, PublicizerAssemblyContext> contexts = Build([], [new TaskItem("Asm")]);
 
@@ -73,7 +73,7 @@ public class GetPublicizerAssemblyContextsTests
     }
 
     [Test]
-    public void DoNotPublicizeMember_AddsDoNotPublicizeMemberPattern()
+    public static void DoNotPublicizeMember_AddsDoNotPublicizeMemberPattern()
     {
         Dictionary<string, PublicizerAssemblyContext> contexts = Build([], [new TaskItem("Asm:Ns.Type.Member")]);
 
@@ -81,7 +81,7 @@ public class GetPublicizerAssemblyContextsTests
     }
 
     [Test]
-    public void SameAssemblyInPublicizeAndDoNotPublicize_MergesIntoOneContext()
+    public static void SameAssemblyInPublicizeAndDoNotPublicize_MergesIntoOneContext()
     {
         Dictionary<string, PublicizerAssemblyContext> contexts = Build([new TaskItem("Asm")], [new TaskItem("Asm:Ns.Type.Member")]);
 

--- a/src/Publicizer.Tests/GetPublicizerAssemblyContextsTests.cs
+++ b/src/Publicizer.Tests/GetPublicizerAssemblyContextsTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;

--- a/src/Publicizer.Tests/HasherTests.cs
+++ b/src/Publicizer.Tests/HasherTests.cs
@@ -8,7 +8,7 @@ namespace Publicizer.Tests;
 /// stable for equal inputs and must change when any input that affects
 /// publicization output changes.
 /// </summary>
-public partial class HasherTests
+internal static partial class HasherTests
 {
     [GeneratedRegex(".*Foo.*")]
     private static partial Regex FooPattern();
@@ -16,7 +16,7 @@ public partial class HasherTests
     private static string Hash(PublicizerAssemblyContext context) => Hasher.ComputeHash(Fixtures.ShapesPath(), context);
 
     [Test]
-    public void ComputeHash_SameInputs_IsStable()
+    public static void ComputeHash_SameInputs_IsStable()
     {
         string first = Hash(new PublicizerAssemblyContext("Fixture"));
         string second = Hash(new PublicizerAssemblyContext("Fixture"));
@@ -25,7 +25,7 @@ public partial class HasherTests
     }
 
     [Test]
-    public void ComputeHash_DifferentAssemblyName_ChangesHash()
+    public static void ComputeHash_DifferentAssemblyName_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));
         string other = Hash(new PublicizerAssemblyContext("Other"));
@@ -34,7 +34,7 @@ public partial class HasherTests
     }
 
     [Test]
-    public void ComputeHash_TogglingIncludeCompilerGeneratedMembers_ChangesHash()
+    public static void ComputeHash_TogglingIncludeCompilerGeneratedMembers_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));
         var context = new PublicizerAssemblyContext("Fixture") { IncludeCompilerGeneratedMembers = false };
@@ -43,7 +43,7 @@ public partial class HasherTests
     }
 
     [Test]
-    public void ComputeHash_TogglingIncludeVirtualMembers_ChangesHash()
+    public static void ComputeHash_TogglingIncludeVirtualMembers_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));
         var context = new PublicizerAssemblyContext("Fixture") { IncludeVirtualMembers = false };
@@ -52,7 +52,7 @@ public partial class HasherTests
     }
 
     [Test]
-    public void ComputeHash_TogglingExplicitlyPublicizeAssembly_ChangesHash()
+    public static void ComputeHash_TogglingExplicitlyPublicizeAssembly_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));
         var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyPublicizeAssembly = true };
@@ -61,7 +61,7 @@ public partial class HasherTests
     }
 
     [Test]
-    public void ComputeHash_TogglingExplicitlyDoNotPublicizeAssembly_ChangesHash()
+    public static void ComputeHash_TogglingExplicitlyDoNotPublicizeAssembly_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));
         var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyDoNotPublicizeAssembly = true };
@@ -70,7 +70,7 @@ public partial class HasherTests
     }
 
     [Test]
-    public void ComputeHash_AddingPublicizeMemberPattern_ChangesHash()
+    public static void ComputeHash_AddingPublicizeMemberPattern_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));
         var context = new PublicizerAssemblyContext("Fixture");
@@ -80,7 +80,7 @@ public partial class HasherTests
     }
 
     [Test]
-    public void ComputeHash_AddingDoNotPublicizeMemberPattern_ChangesHash()
+    public static void ComputeHash_AddingDoNotPublicizeMemberPattern_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));
         var context = new PublicizerAssemblyContext("Fixture");
@@ -90,7 +90,7 @@ public partial class HasherTests
     }
 
     [Test]
-    public void ComputeHash_SettingMemberRegexPattern_ChangesHash()
+    public static void ComputeHash_SettingMemberRegexPattern_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));
         var context = new PublicizerAssemblyContext("Fixture") { PublicizeMemberRegexPattern = FooPattern() };

--- a/src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs
+++ b/src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs
@@ -10,7 +10,7 @@ namespace Publicizer.Tests;
 /// each scenario. These snapshots freeze current behavior so the tree can be refactored
 /// safely: any change to a member's resulting visibility surfaces as a snapshot diff.
 /// </summary>
-public partial class PublicizeAssemblyCharacterizationTests
+internal static partial class PublicizeAssemblyCharacterizationTests
 {
     [GeneratedRegex("Protected")]
     private static partial Regex ProtectedPattern();
@@ -21,7 +21,7 @@ public partial class PublicizeAssemblyCharacterizationTests
         module.Find(typeReflectionName, isReflectionName: true).Fields.Single(f => f.Name == fieldName);
 
     [Test]
-    public void WholeAssembly_Defaults()
+    public static void WholeAssembly_Defaults()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyPublicizeAssembly = true };
@@ -33,7 +33,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void WholeAssembly_ExcludingVirtualMembers()
+    public static void WholeAssembly_ExcludingVirtualMembers()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture")
@@ -48,7 +48,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void WholeAssembly_ExcludingCompilerGeneratedMembers()
+    public static void WholeAssembly_ExcludingCompilerGeneratedMembers()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture")
@@ -63,7 +63,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void WholeAssembly_WithMemberRegexPattern()
+    public static void WholeAssembly_WithMemberRegexPattern()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture")
@@ -78,7 +78,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void SingleMember_Field()
+    public static void SingleMember_Field()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -90,7 +90,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void SingleMember_Property()
+    public static void SingleMember_Property()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -102,7 +102,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void SingleMember_Method()
+    public static void SingleMember_Method()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -114,7 +114,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void SingleMember_Constructor()
+    public static void SingleMember_Constructor()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -126,7 +126,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void WholeAssembly_ExceptOneProperty_LeavesAccessorsUntouched()
+    public static void WholeAssembly_ExceptOneProperty_LeavesAccessorsUntouched()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyPublicizeAssembly = true };
@@ -138,7 +138,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void DoNotPublicizeAssembly_PublicizesNothing()
+    public static void DoNotPublicizeAssembly_PublicizesNothing()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyDoNotPublicizeAssembly = true };
@@ -150,7 +150,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void NestedMember_AlsoPublicizesEnclosingType()
+    public static void NestedMember_AlsoPublicizesEnclosingType()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -162,7 +162,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void PublicizeType_ByName_PublicizesTypeAndWalksUp()
+    public static void PublicizeType_ByName_PublicizesTypeAndWalksUp()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -174,7 +174,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void WholeAssembly_ExceptType_LeavesThatTypesMembersUntouched()
+    public static void WholeAssembly_ExceptType_LeavesThatTypesMembersUntouched()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyPublicizeAssembly = true };
@@ -188,7 +188,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     // --- Event backing field: the original reason for the compiler-generated filter (issue #9). ---
 
     [Test]
-    public void EventBackingField_WholeAssemblyDefault_BecomesPublic_TheCollision()
+    public static void EventBackingField_WholeAssemblyDefault_BecomesPublic_TheCollision()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyPublicizeAssembly = true };
@@ -200,7 +200,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void EventBackingField_ExcludingCompilerGenerated_StaysPrivate()
+    public static void EventBackingField_ExcludingCompilerGenerated_StaysPrivate()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture")
@@ -217,7 +217,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     // --- Precedence and generics. ---
 
     [Test]
-    public void MemberInBothPublicizeAndDoNotPublicize_DoNotPublicizeWins()
+    public static void MemberInBothPublicizeAndDoNotPublicize_DoNotPublicizeWins()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -230,7 +230,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void SingleMember_GenericField_MatchesArityMangledName()
+    public static void SingleMember_GenericField_MatchesArityMangledName()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -242,7 +242,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void PublicizeTarget_MatchesNothing_PublicizesNothingAndReturnsFalse()
+    public static void PublicizeTarget_MatchesNothing_PublicizesNothingAndReturnsFalse()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -258,7 +258,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void ExplicitMemberPublicize_BeatsDoNotPublicizeType()
+    public static void ExplicitMemberPublicize_BeatsDoNotPublicizeType()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture");
@@ -274,7 +274,7 @@ public partial class PublicizeAssemblyCharacterizationTests
     }
 
     [Test]
-    public void DoNotPublicizeEvent_ByName_ExcludesBackingField()
+    public static void DoNotPublicizeEvent_ByName_ExcludesBackingField()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyPublicizeAssembly = true };

--- a/src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs
+++ b/src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Text.RegularExpressions;
 using dnlib.DotNet;
 using NUnit.Framework;

--- a/src/Publicizer.Tests/Publicizer.Tests.csproj
+++ b/src/Publicizer.Tests/Publicizer.Tests.csproj
@@ -6,16 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="Microsoft.Build.Utilities.Core"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
+    <PackageReference Include="NUnit"/>
+    <PackageReference Include="NUnit3TestAdapter"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Publicizer\Publicizer.csproj" />
+    <ProjectReference Include="..\Publicizer\Publicizer.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Publicizer.Tests/TaskItemExtensionsTests.cs
+++ b/src/Publicizer.Tests/TaskItemExtensionsTests.cs
@@ -8,17 +8,17 @@ namespace Publicizer.Tests;
 /// Characterizes <see cref="TaskItemExtensions"/>: metadata parsing and its
 /// default-to-true / null-on-blank behavior.
 /// </summary>
-public class TaskItemExtensionsTests
+internal static class TaskItemExtensionsTests
 {
     [Test]
-    public void IncludeCompilerGeneratedMembers_MissingMetadata_DefaultsToTrue()
+    public static void IncludeCompilerGeneratedMembers_MissingMetadata_DefaultsToTrue()
     {
         var item = new TaskItem("Asm");
         Assert.That(item.IncludeCompilerGeneratedMembers(), Is.True);
     }
 
     [Test]
-    public void IncludeCompilerGeneratedMembers_GarbageMetadata_DefaultsToTrue()
+    public static void IncludeCompilerGeneratedMembers_GarbageMetadata_DefaultsToTrue()
     {
         var item = new TaskItem("Asm");
         item.SetMetadata("IncludeCompilerGeneratedMembers", "notabool");
@@ -26,7 +26,7 @@ public class TaskItemExtensionsTests
     }
 
     [Test]
-    public void IncludeCompilerGeneratedMembers_False_IsFalse()
+    public static void IncludeCompilerGeneratedMembers_False_IsFalse()
     {
         var item = new TaskItem("Asm");
         item.SetMetadata("IncludeCompilerGeneratedMembers", "false");
@@ -34,14 +34,14 @@ public class TaskItemExtensionsTests
     }
 
     [Test]
-    public void IncludeVirtualMembers_MissingMetadata_DefaultsToTrue()
+    public static void IncludeVirtualMembers_MissingMetadata_DefaultsToTrue()
     {
         var item = new TaskItem("Asm");
         Assert.That(item.IncludeVirtualMembers(), Is.True);
     }
 
     [Test]
-    public void IncludeVirtualMembers_False_IsFalse()
+    public static void IncludeVirtualMembers_False_IsFalse()
     {
         var item = new TaskItem("Asm");
         item.SetMetadata("IncludeVirtualMembers", "false");
@@ -49,14 +49,14 @@ public class TaskItemExtensionsTests
     }
 
     [Test]
-    public void MemberPattern_MissingMetadata_IsNull()
+    public static void MemberPattern_MissingMetadata_IsNull()
     {
         var item = new TaskItem("Asm");
         Assert.That(item.MemberPattern(), Is.Null);
     }
 
     [Test]
-    public void MemberPattern_BlankMetadata_IsNull()
+    public static void MemberPattern_BlankMetadata_IsNull()
     {
         var item = new TaskItem("Asm");
         item.SetMetadata("MemberPattern", "   ");
@@ -64,7 +64,7 @@ public class TaskItemExtensionsTests
     }
 
     [Test]
-    public void MemberPattern_Set_ReturnsMatchingRegex()
+    public static void MemberPattern_Set_ReturnsMatchingRegex()
     {
         var item = new TaskItem("Asm");
         item.SetMetadata("MemberPattern", ".*Foo.*");
@@ -77,7 +77,7 @@ public class TaskItemExtensionsTests
     }
 
     [Test]
-    public void FileName_ReturnsFileNameWithoutExtension()
+    public static void FileName_ReturnsFileNameWithoutExtension()
     {
         var item = new TaskItem("/some/dir/PrivateAssembly.dll");
         Assert.That(item.FileName(), Is.EqualTo("PrivateAssembly"));

--- a/src/Publicizer.Tests/TemporaryFolder.cs
+++ b/src/Publicizer.Tests/TemporaryFolder.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-
 namespace Publicizer.Tests;
 
 internal sealed class TemporaryFolder : IDisposable

--- a/src/Publicizer/Hasher.cs
+++ b/src/Publicizer/Hasher.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
@@ -14,7 +12,7 @@ internal static class Hasher
     // Includes the commit hash via SourceLink, so it changes on every build.
     // Feeding it into the cache key invalidates assemblies publicized by an
     // older Publicizer whose publicization logic may have differed.
-    private static readonly string PublicizerVersion =
+    private static readonly string s_publicizerVersion =
         typeof(Hasher).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
@@ -23,7 +21,7 @@ internal static class Hasher
     internal static string ComputeHash(string assemblyPath, PublicizerAssemblyContext assemblyContext)
     {
         var sb = new StringBuilder();
-        sb.Append(PublicizerVersion);
+        sb.Append(s_publicizerVersion);
         sb.Append(assemblyContext.AssemblyName);
         sb.Append(assemblyContext.IncludeCompilerGeneratedMembers);
         sb.Append(assemblyContext.IncludeVirtualMembers);
@@ -44,7 +42,7 @@ internal static class Hasher
 
         byte[] patternBytes = Encoding.UTF8.GetBytes(sb.ToString());
         byte[] assemblyBytes = File.ReadAllBytes(assemblyPath);
-        byte[] allBytes = assemblyBytes.Concat(patternBytes).ToArray();
+        byte[] allBytes = [.. assemblyBytes, .. patternBytes];
 
         return ComputeHash(allBytes);
     }

--- a/src/Publicizer/ITaskLogger.cs
+++ b/src/Publicizer/ITaskLogger.cs
@@ -2,8 +2,8 @@
 
 public interface ITaskLogger
 {
-    public void Error(string message);
-    public void Warning(string message);
-    public void Info(string message);
-    public void Verbose(string message);
+    void Error(string message);
+    void Warning(string message);
+    void Info(string message);
+    void Verbose(string message);
 }

--- a/src/Publicizer/Logger.cs
+++ b/src/Publicizer/Logger.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -1,13 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using dnlib.DotNet;
 using dnlib.DotNet.Writer;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Task = Microsoft.Build.Utilities.Task;
 
 namespace Publicizer;
+
 public sealed class PublicizeAssemblies : Task
 {
     [Required]
@@ -57,8 +55,8 @@ public sealed class PublicizeAssemblies : Task
         using Logger logger = GetLogger();
         logger.Info($"Initializing assembly publicization");
 
-        Publicizes ??= Array.Empty<ITaskItem>();
-        DoNotPublicizes ??= Array.Empty<ITaskItem>();
+        Publicizes ??= [];
+        DoNotPublicizes ??= [];
 
         logger.Info($"Referenced assemblies: {ReferencePaths.Length}");
 
@@ -150,8 +148,8 @@ public sealed class PublicizeAssemblies : Task
             scopedLogger.Info("Assembly processing finished");
         }
 
-        ReferencePathsToDelete = referencePathsToDelete.ToArray();
-        ReferencePathsToAdd = referencePathsToAdd.ToArray();
+        ReferencePathsToDelete = [.. referencePathsToDelete];
+        ReferencePathsToAdd = [.. referencePathsToAdd];
 
         logger.Info($"Finished processing {assemblyContexts.Count} assemblies. Terminating task.");
 
@@ -240,7 +238,7 @@ public sealed class PublicizeAssemblies : Task
             string typeName = typeDef.ReflectionFullName;
 
             bool explicitlyDoNotPublicizeType = assemblyContext.DoNotPublicizeMemberPatterns.Contains(typeName);
-            
+
             // PROPERTIES
             foreach (PropertyDef? propertyDef in typeDef.Properties)
             {
@@ -291,7 +289,7 @@ public sealed class PublicizeAssemblies : Task
                     {
                         continue;
                     }
-                    
+
                     bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(propertyName) ?? true;
                     if (!isRegexPatternMatch)
                     {
@@ -355,7 +353,7 @@ public sealed class PublicizeAssemblies : Task
                     {
                         continue;
                     }
-                    
+
                     bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(methodName) ?? true;
                     if (!isRegexPatternMatch)
                     {
@@ -413,7 +411,7 @@ public sealed class PublicizeAssemblies : Task
                     {
                         continue;
                     }
-                    
+
                     bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(fieldName) ?? true;
                     if (!isRegexPatternMatch)
                     {

--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -12,7 +12,6 @@
     <OutDir Condition="$(OutDir) == ''">bin</OutDir>
     <PackageOutputPath>$(OutDir)</PackageOutputPath>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludePackageDependencies</TargetsForTfmSpecificBuildOutput>
-    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <PropertyGroup Label="Package properties">

--- a/src/Publicizer/Publicizer.csproj
+++ b/src/Publicizer/Publicizer.csproj
@@ -29,27 +29,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Publicizer.Tests" />
+    <InternalsVisibleTo Include="Publicizer.Tests"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="dnlib" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
-    <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="all" />
+    <PackageReference Include="dnlib"/>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all"/>
+    <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <Content Include="Krafs.Publicizer.props" PackagePath="build" />
-    <Content Include="Krafs.Publicizer.targets" PackagePath="build" />
-    <Compile Remove="IgnoresAccessChecksToAttribute.cs" />
-    <Content Include="IgnoresAccessChecksToAttribute.cs" PackagePath="contentfiles\cs\any\Publicizer" />
+    <None Include="..\..\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <Content Include="Krafs.Publicizer.props" PackagePath="build"/>
+    <Content Include="Krafs.Publicizer.targets" PackagePath="build"/>
+    <Compile Remove="IgnoresAccessChecksToAttribute.cs"/>
+    <Content Include="IgnoresAccessChecksToAttribute.cs" PackagePath="contentfiles\cs\any\Publicizer"/>
   </ItemGroup>
 
   <Target Name="IncludePackageDependencies">
     <ItemGroup>
-      <BuildOutputInPackage Include="$(OutDir)dnlib.dll" />
+      <BuildOutputInPackage Include="$(OutDir)dnlib.dll"/>
     </ItemGroup>
   </Target>
 
@@ -58,9 +58,9 @@
        package (e.g. a previous release) would otherwise shadow this build. -->
   <Target Name="CleanStalePackages" BeforeTargets="GenerateNuspec">
     <ItemGroup>
-      <_StalePackage Include="$([MSBuild]::EnsureTrailingSlash($(PackageOutputPath)))Krafs.Publicizer.*.nupkg" />
+      <_StalePackage Include="$([MSBuild]::EnsureTrailingSlash($(PackageOutputPath)))Krafs.Publicizer.*.nupkg"/>
     </ItemGroup>
-    <Delete Files="@(_StalePackage)" />
+    <Delete Files="@(_StalePackage)"/>
   </Target>
 
 </Project>

--- a/src/Publicizer/PublicizerAssemblyContext.cs
+++ b/src/Publicizer/PublicizerAssemblyContext.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Publicizer;
@@ -15,7 +14,7 @@ internal sealed class PublicizerAssemblyContext
     internal bool IncludeCompilerGeneratedMembers { get; set; } = true;
     internal bool IncludeVirtualMembers { get; set; } = true;
     internal bool ExplicitlyDoNotPublicizeAssembly { get; set; } = false;
-    internal HashSet<string> PublicizeMemberPatterns { get; } = new HashSet<string>();
+    internal HashSet<string> PublicizeMemberPatterns { get; } = [];
     internal Regex? PublicizeMemberRegexPattern { get; set; }
-    internal HashSet<string> DoNotPublicizeMemberPatterns { get; } = new HashSet<string>();
+    internal HashSet<string> DoNotPublicizeMemberPatterns { get; } = [];
 }

--- a/src/Publicizer/TaskItemExtensions.cs
+++ b/src/Publicizer/TaskItemExtensions.cs
@@ -34,7 +34,7 @@ internal static class TaskItemExtensions
 
         return true;
     }
-    
+
     internal static Regex? MemberPattern(this ITaskItem item)
     {
         string? memberPattern = item.GetMetadata("MemberPattern");


### PR DESCRIPTION
Move `AnalysisMode=All` and `EnforceCodeStyleInBuild` into `Directory.Build.props` so the test projects are analyzed too, and turn on `ImplicitUsings`. Includes the resulting CA/IDE cleanup pass.

- `GenerateDocumentationFile` is on because IDE0005 (unnecessary usings) is silently skipped at build without it; CS1591 is muted in return.
- Test fixtures become `internal static`. Internal alone would only trade CA1515 for CA1812; static satisfies both, and no fixture held instance state.
- Two `.editorconfig` spacing values were unparseable (`do_not_ignore`, and a bool where a list belongs). Roslyn fell back to the intended behaviour for both, so nothing changes at build — but Rider rejects them.