### PR TITLE
Trim editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,33 +37,12 @@ dotnet_naming_symbols.constants.required_modifiers = const
 
 dotnet_naming_style.constant_style.capitalization = pascal_case
 
-# Static fields are camelCase and start with s_
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
-dotnet_naming_rule.static_fields_should_be_camel_case.symbols = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style = static_field_style
+# Fields, locals and parameters are camelCase
+dotnet_naming_rule.fields_locals_and_parameters_should_be_camel_case.severity = warning
+dotnet_naming_rule.fields_locals_and_parameters_should_be_camel_case.symbols = fields_locals_and_parameters
+dotnet_naming_rule.fields_locals_and_parameters_should_be_camel_case.style = camel_case_style
 
-dotnet_naming_symbols.static_fields.applicable_kinds = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-
-dotnet_naming_style.static_field_style.capitalization = camel_case
-dotnet_naming_style.static_field_style.required_prefix = s_
-
-# Instance fields are camelCase and start with _
-dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
-dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
-dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
-
-dotnet_naming_symbols.instance_fields.applicable_kinds = field
-
-dotnet_naming_style.instance_field_style.capitalization = camel_case
-dotnet_naming_style.instance_field_style.required_prefix = _
-
-# Locals and parameters are camelCase
-dotnet_naming_rule.locals_should_be_camel_case.severity = warning
-dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
-dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
-
-dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+dotnet_naming_symbols.fields_locals_and_parameters.applicable_kinds = field, parameter, local
 
 dotnet_naming_style.camel_case_style.capitalization = camel_case
 
@@ -80,10 +59,6 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 csharp_style_namespace_declarations = file_scoped
 csharp_style_var_when_type_is_apparent = true
 csharp_style_expression_bodied_methods = when_on_single_line
-dotnet_style_allow_multiple_blank_lines_experimental = false
-csharp_style_allow_embedded_statements_on_same_line_experimental = false
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
 
 # IDE0058: requiring every return value to be consumed is noise.
 dotnet_diagnostic.IDE0058.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,65 +13,22 @@ indent_style = space
 [*.{csproj,props,targets}]
 indent_size = 2
 
-# Dotnet code style settings:
 [*.cs]
 indent_size = 4
 insert_final_newline = true
 charset = utf-8
 
+# Enforce every analyzer and code-style rule at build. Everything below is an
+# exception to this line: either a preference whose default we disagree with, or
+# a rule we've deliberately opted out of.
 dotnet_analyzer_diagnostic.severity = warning
 
-# IDE0055: Fix formatting
-dotnet_diagnostic.IDE0055.severity = warning
-
-# Sort using and Import directives with System.* appearing first
-dotnet_sort_system_directives_first = true
-dotnet_separate_import_directive_groups = false
-
-# Avoid "this." and "Me." if not necessary
-dotnet_style_qualification_for_field = false:refactoring
-dotnet_style_qualification_for_property = false:refactoring
-dotnet_style_qualification_for_method = false:refactoring
-dotnet_style_qualification_for_event = false:refactoring
-
-# Use language keywords instead of framework type names for type references
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-# Suggest more modern language features when available
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-
-# Whitespace options
-dotnet_style_allow_multiple_blank_lines_experimental = false
-
-# Non-private static fields are PascalCase
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
-
-dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
-dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
-dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
-
-dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
-
-# Non-private readonly fields are PascalCase
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
-
-dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
-dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
-dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
-
-dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+# Roslyn ships no naming rules of its own, so these are the whole convention.
+# Order matters: the first rule whose symbol spec matches wins, so the catch-all
+# goes last and every rule above it exists to carve an exception out of it.
 
 # Constants are PascalCase
-dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
 dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
 dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
 
@@ -81,7 +38,7 @@ dotnet_naming_symbols.constants.required_modifiers = const
 dotnet_naming_style.constant_style.capitalization = pascal_case
 
 # Static fields are camelCase and start with s_
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
 dotnet_naming_rule.static_fields_should_be_camel_case.symbols = static_fields
 dotnet_naming_rule.static_fields_should_be_camel_case.style = static_field_style
 
@@ -92,7 +49,7 @@ dotnet_naming_style.static_field_style.capitalization = camel_case
 dotnet_naming_style.static_field_style.required_prefix = s_
 
 # Instance fields are camelCase and start with _
-dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
 dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
 dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
 
@@ -102,7 +59,7 @@ dotnet_naming_style.instance_field_style.capitalization = camel_case
 dotnet_naming_style.instance_field_style.required_prefix = _
 
 # Locals and parameters are camelCase
-dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
 dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
 dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
 
@@ -110,17 +67,8 @@ dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
 
 dotnet_naming_style.camel_case_style.capitalization = camel_case
 
-# Local functions are PascalCase
-dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
-dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
-
-dotnet_naming_symbols.local_functions.applicable_kinds = local_function
-
-dotnet_naming_style.local_function_style.capitalization = pascal_case
-
 # By default, name items with PascalCase
-dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
 dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
 dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
 
@@ -128,139 +76,17 @@ dotnet_naming_symbols.all_members.applicable_kinds = *
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-# IDE0035: Remove unreachable code
-dotnet_diagnostic.IDE0035.severity = warning
-
-# IDE0036: Order modifiers
-dotnet_diagnostic.IDE0036.severity = warning
-
-# IDE0043: Format string contains invalid placeholder
-dotnet_diagnostic.IDE0043.severity = warning
-
-# IDE0044: Make field readonly
-dotnet_diagnostic.IDE0044.severity = warning
-
-# IDE0051: Remove unused private member
-dotnet_diagnostic.IDE0051.severity = warning
-
-# IDE0170: Prefer extended property pattern
-dotnet_diagnostic.IDE0170.severity = warning
-
-# Newline settings
-csharp_new_line_before_open_brace = all
-csharp_new_line_before_else = true
-csharp_new_line_before_catch = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_between_query_expression_clauses = true
-
-# Indentation preferences
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
-csharp_indent_switch_labels = true
-csharp_indent_labels = flush_left
-
-# Whitespace options
+# Defaults we disagree with.
+csharp_style_namespace_declarations = file_scoped
+csharp_style_var_when_type_is_apparent = true
+csharp_style_expression_bodied_methods = when_on_single_line
+dotnet_style_allow_multiple_blank_lines_experimental = false
 csharp_style_allow_embedded_statements_on_same_line_experimental = false
 csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
 
-# Prefer method-like constructs to have a block body
-csharp_style_expression_bodied_methods = false:none
-csharp_style_expression_bodied_constructors = false:none
-csharp_style_expression_bodied_operators = false:none
-
-# Prefer property-like constructs to have an expression-body
-csharp_style_expression_bodied_properties = true:none
-csharp_style_expression_bodied_indexers = true:none
-csharp_style_expression_bodied_accessors = true:none
-
-# Suggest more modern language features when available
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-csharp_style_prefer_extended_property_pattern = true:suggestion
-
-# Space preferences
-csharp_space_after_cast = false
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_after_comma = true
-csharp_space_after_dot = false
-csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_after_semicolon_in_for_statement = true
-csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = false
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_before_comma = false
-csharp_space_before_dot = false
-csharp_space_before_open_square_brackets = false
-csharp_space_before_semicolon_in_for_statement = false
-csharp_space_between_empty_square_brackets = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_square_brackets = false
-
-# Blocks are allowed
-csharp_prefer_braces = true:warning
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = true
-
-# IDE0160: Convert to file-scoped namespace
-csharp_style_namespace_declarations = file_scoped:warning
-
-# IDE0040: Add accessibility modifiers
-dotnet_diagnostic.IDE0040.severity = warning
-
-# IDE0052: Remove unread private member
-dotnet_diagnostic.IDE0052.severity = warning
-
-# IDE0059: Unnecessary assignment to a value
-dotnet_diagnostic.IDE0059.severity = warning
-
-# IDE0060: Remove unused parameter
-dotnet_diagnostic.IDE0060.severity = warning
-
-# CA1012: Abstract types should not have public constructors
-dotnet_diagnostic.CA1012.severity = warning
-
-# CA1822: Make member static
-dotnet_diagnostic.CA1822.severity = warning
-
-# Prefer "var" everywhere
-dotnet_diagnostic.IDE0007.severity = warning
-csharp_style_var_for_built_in_types = false:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = false:warning
-
-# dotnet_style_allow_multiple_blank_lines_experimental
-dotnet_diagnostic.IDE2000.severity = warning
-
-# csharp_style_allow_embedded_statements_on_same_line_experimental
-dotnet_diagnostic.IDE2001.severity = warning
-
-# csharp_style_allow_blank_lines_between_consecutive_braces_experimental
-dotnet_diagnostic.IDE2002.severity = warning
-
-# dotnet_style_allow_statement_immediately_after_block_experimental
-dotnet_diagnostic.IDE2003.severity = warning
-
-# csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental
-dotnet_diagnostic.IDE2004.severity = warning
-
-# CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = none
-
-# IDE0058: Expression value is never used
+# IDE0058: requiring every return value to be consumed is noise.
 dotnet_diagnostic.IDE0058.severity = none
 
-# IDE0046: Convert to conditional expression
+# IDE0046: nested conditional expressions read worse than early returns.
 dotnet_diagnostic.IDE0046.severity = silent

--- a/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
+++ b/src/Publicizer.E2ETests/DesignTimeBuildTests.cs
@@ -10,7 +10,7 @@ namespace Publicizer.E2ETests;
 internal static class DesignTimeBuildTests
 {
     // The properties the .NET Project System sets for a design-time build.
-    private static readonly string[] s_designTimeBuildArguments =
+    private static readonly string[] designTimeBuildArguments =
     [
         "-t:DumpReferencePaths",
         "-p:DesignTimeBuild=true",
@@ -39,7 +39,7 @@ internal static class DesignTimeBuildTests
             .Item("Publicize", "PrivateAssembly")
             .RawXml(DumpTarget);
 
-        ProcessResult result = app.Build(s_designTimeBuildArguments);
+        ProcessResult result = app.Build(designTimeBuildArguments);
         Assert.That(result.ExitCode, Is.Zero, result.Output);
 
         string[] referencePaths = File.ReadAllLines(Path.Combine(app.Folder, "referencepaths.txt"));

--- a/src/Publicizer.E2ETests/TemporaryFolder.cs
+++ b/src/Publicizer.E2ETests/TemporaryFolder.cs
@@ -2,17 +2,17 @@ namespace Publicizer.E2ETests;
 
 internal sealed class TemporaryFolder : IDisposable
 {
-    private readonly DirectoryInfo _directoryInfo;
+    private readonly DirectoryInfo directoryInfo;
     internal TemporaryFolder()
     {
         string path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
 
-        _directoryInfo = Directory.CreateDirectory(path);
+        directoryInfo = Directory.CreateDirectory(path);
     }
 
-    internal string Path => _directoryInfo.FullName;
+    internal string Path => directoryInfo.FullName;
 
-    public override string ToString() => _directoryInfo.FullName;
+    public override string ToString() => directoryInfo.FullName;
 
-    void IDisposable.Dispose() => _directoryInfo.Delete(recursive: true);
+    void IDisposable.Dispose() => directoryInfo.Delete(recursive: true);
 }

--- a/src/Publicizer.E2ETests/TemporaryFolder.cs
+++ b/src/Publicizer.E2ETests/TemporaryFolder.cs
@@ -12,13 +12,7 @@ internal sealed class TemporaryFolder : IDisposable
 
     internal string Path => _directoryInfo.FullName;
 
-    public override string ToString()
-    {
-        return _directoryInfo.FullName;
-    }
+    public override string ToString() => _directoryInfo.FullName;
 
-    void IDisposable.Dispose()
-    {
-        _directoryInfo.Delete(recursive: true);
-    }
+    void IDisposable.Dispose() => _directoryInfo.Delete(recursive: true);
 }

--- a/src/Publicizer.E2ETests/TestProject.cs
+++ b/src/Publicizer.E2ETests/TestProject.cs
@@ -11,49 +11,49 @@ internal sealed class TestProject : IDisposable
     // nothing collides across tests and the reference can be pinned exactly.
     private const string PackageVersion = "1.0.0";
 
-    private readonly TemporaryFolder _folder = new();
-    private readonly string _name;
-    private readonly string _outputType;
-    private readonly string _sourcePath;
-    private readonly List<string> _properties = [];
-    private readonly List<string> _items = [];
-    private readonly List<string> _rawXml = [];
-    private readonly List<LocalPackageSource> _packageSources = [];
-    private List<string> _targetFrameworks = [DefaultTargetFramework];
+    private readonly TemporaryFolder folder = new();
+    private readonly string name;
+    private readonly string outputType;
+    private readonly string sourcePath;
+    private readonly List<string> properties = [];
+    private readonly List<string> items = [];
+    private readonly List<string> rawXml = [];
+    private readonly List<LocalPackageSource> packageSources = [];
+    private List<string> targetFrameworks = [DefaultTargetFramework];
 
     private TestProject(string name, string outputType, string sourceCode)
     {
-        _name = name;
-        _outputType = outputType;
-        _sourcePath = Path.Combine(_folder.Path, "Source.cs");
-        File.WriteAllText(_sourcePath, sourceCode);
+        this.name = name;
+        this.outputType = outputType;
+        sourcePath = Path.Combine(folder.Path, "Source.cs");
+        File.WriteAllText(sourcePath, sourceCode);
     }
 
     internal static TestProject Library(string name, string sourceCode) => new(name, "library", sourceCode);
 
     internal static TestProject App(string sourceCode) => new("App", "exe", sourceCode);
 
-    internal string Folder => _folder.Path;
+    internal string Folder => folder.Path;
 
     // Output goes to a subfolder, not the project directory: with the two the same, a
     // consumer's copy-local of a reference lands next to its own project and gets resolved
     // in preference to the HintPath on the next build — stale, and nothing to do with the
     // code under test.
-    private string OutputFolder => Path.Combine(_folder.Path, "bin");
+    private string OutputFolder => Path.Combine(folder.Path, "bin");
 
-    private bool IsMultiTargeted => _targetFrameworks.Count > 1;
+    private bool IsMultiTargeted => targetFrameworks.Count > 1;
 
-    private bool TargetsNetFramework => _targetFrameworks[0].StartsWith("net4", StringComparison.Ordinal);
+    private bool TargetsNetFramework => targetFrameworks[0].StartsWith("net4", StringComparison.Ordinal);
 
-    private string PackageFolder => Path.Combine(_folder.Path, "package");
+    private string PackageFolder => Path.Combine(folder.Path, "package");
 
-    internal string AssemblyPath => AssemblyPathFor(_targetFrameworks[0]);
+    internal string AssemblyPath => AssemblyPathFor(targetFrameworks[0]);
 
-    internal string ProjectPath => Path.Combine(_folder.Path, $"{_name}.csproj");
+    internal string ProjectPath => Path.Combine(folder.Path, $"{name}.csproj");
 
     // Multi-targeted builds give each inner build its own OutDir, so an assembly is only
     // addressable per target framework.
-    internal string AssemblyPathFor(string targetFramework) => Path.Combine(IsMultiTargeted ? Path.Combine(OutputFolder, targetFramework) : OutputFolder, $"{_name}.dll");
+    internal string AssemblyPathFor(string targetFramework) => Path.Combine(IsMultiTargeted ? Path.Combine(OutputFolder, targetFramework) : OutputFolder, $"{name}.dll");
 
     // .NET Framework consumers resolve references through a different set of search paths
     // and reference assemblies than .NET ones.
@@ -63,28 +63,28 @@ internal sealed class TestProject : IDisposable
     // own IntermediateOutputPath and its own pass over the references.
     internal TestProject TargetingFrameworks(params string[] targetFrameworks)
     {
-        _targetFrameworks = [.. targetFrameworks];
+        this.targetFrameworks = [.. targetFrameworks];
         return this;
     }
 
     internal TestProject Property(string name, string value)
     {
-        _properties.Add($"<{name}>{value}</{name}>");
+        properties.Add($"<{name}>{value}</{name}>");
         return this;
     }
 
     internal TestProject Item(string type, string include, string? attributes = null)
     {
-        _items.Add($"""<{type} Include="{include}"{(attributes is null ? "" : " " + attributes)} />""");
+        items.Add($"""<{type} Include="{include}"{(attributes is null ? "" : " " + attributes)} />""");
         return this;
     }
 
-    internal TestProject Referencing(TestProject other) => Item("Reference", other._name, $"""HintPath="{other.AssemblyPath}" """);
+    internal TestProject Referencing(TestProject other) => Item("Reference", other.name, $"""HintPath="{other.AssemblyPath}" """);
 
     // The PackageReference plus the local source that resolves it from the locally packed nupkg.
     internal TestProject ConsumingPublicizer()
     {
-        _packageSources.Add(new LocalPackageSource("publicizer", NugetConfigMaker.PublicizerPackagesFolder, "Krafs.Publicizer"));
+        packageSources.Add(new LocalPackageSource("publicizer", NugetConfigMaker.PublicizerPackagesFolder, "Krafs.Publicizer"));
         return Item("PackageReference", "Krafs.Publicizer", """Version="*" """);
     }
 
@@ -93,14 +93,14 @@ internal sealed class TestProject : IDisposable
     // other project to have been packed.
     internal TestProject ReferencingPackage(TestProject other)
     {
-        _packageSources.Add(new LocalPackageSource(other._name, other.PackageFolder, other._name));
-        return Item("PackageReference", other._name, $"""Version="{PackageVersion}" """);
+        packageSources.Add(new LocalPackageSource(other.name, other.PackageFolder, other.name));
+        return Item("PackageReference", other.name, $"""Version="{PackageVersion}" """);
     }
 
     // Raw XML appended inside the project, for the odd test that needs a target of its own.
     internal TestProject RawXml(string xml)
     {
-        _rawXml.Add(xml);
+        rawXml.Add(xml);
         return this;
     }
 
@@ -120,7 +120,7 @@ internal sealed class TestProject : IDisposable
         ProcessResult result = Runner.Pack(ProjectPath);
         if (result.ExitCode != 0)
         {
-            throw new InvalidOperationException($"Packing {_name} failed with exit code {result.ExitCode}:{Environment.NewLine}{result.Output}{result.Error}");
+            throw new InvalidOperationException($"Packing {name} failed with exit code {result.ExitCode}:{Environment.NewLine}{result.Output}{result.Error}");
         }
         return this;
     }
@@ -137,15 +137,15 @@ internal sealed class TestProject : IDisposable
     private void Materialize()
     {
         File.WriteAllText(ProjectPath, ToCsproj());
-        if (_packageSources.Count > 0)
+        if (packageSources.Count > 0)
         {
-            NugetConfigMaker.CreateConfig(_folder.Path, _packageSources);
+            NugetConfigMaker.CreateConfig(folder.Path, packageSources);
         }
     }
 
     internal TestProject Rewrite(string sourceCode)
     {
-        File.WriteAllText(_sourcePath, sourceCode);
+        File.WriteAllText(sourcePath, sourceCode);
         return this;
     }
 
@@ -155,25 +155,25 @@ internal sealed class TestProject : IDisposable
         ProcessResult result = Build();
         if (result.ExitCode != 0)
         {
-            throw new InvalidOperationException($"Building {_name} failed with exit code {result.ExitCode}:{Environment.NewLine}{result.Output}{result.Error}");
+            throw new InvalidOperationException($"Building {name} failed with exit code {result.ExitCode}:{Environment.NewLine}{result.Output}{result.Error}");
         }
         return this;
     }
 
     // .NET Framework apps produce a runnable .exe; .NET apps are launched through the host.
     internal ProcessResult Run() => TargetsNetFramework
-        ? Runner.Run(Path.Combine(OutputFolder, $"{_name}.exe"))
+        ? Runner.Run(Path.Combine(OutputFolder, $"{name}.exe"))
         : Runner.Run("dotnet", AssemblyPath);
 
     private string ToCsproj()
     {
-        string properties = string.Join(Environment.NewLine + "    ", _properties);
-        string items = string.Join(Environment.NewLine + "    ", _items);
-        string rawXml = string.Join(Environment.NewLine, _rawXml);
+        string propertiesXml = string.Join(Environment.NewLine + "    ", properties);
+        string itemsXml = string.Join(Environment.NewLine + "    ", items);
+        string rawXmlText = string.Join(Environment.NewLine, rawXml);
 
-        string targetFrameworks = IsMultiTargeted
-            ? $"<TargetFrameworks>{string.Join(";", _targetFrameworks)}</TargetFrameworks>"
-            : $"<TargetFramework>{_targetFrameworks[0]}</TargetFramework>";
+        string targetFrameworksXml = IsMultiTargeted
+            ? $"<TargetFrameworks>{string.Join(";", targetFrameworks)}</TargetFrameworks>"
+            : $"<TargetFramework>{targetFrameworks[0]}</TargetFramework>";
 
         // Inner builds would otherwise all write to the same OutDir and overwrite each other.
         string outDir = IsMultiTargeted
@@ -184,23 +184,23 @@ internal sealed class TestProject : IDisposable
             <Project Sdk="Microsoft.NET.Sdk">
 
               <PropertyGroup>
-                {targetFrameworks}
+                {targetFrameworksXml}
                 <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-                <OutputType>{_outputType}</OutputType>
+                <OutputType>{outputType}</OutputType>
                 <OutDir>{outDir}</OutDir>
-                {properties}
+                {propertiesXml}
               </PropertyGroup>
 
               <ItemGroup>
-                <Compile Include="{_sourcePath}" />
-                {items}
+                <Compile Include="{sourcePath}" />
+                {itemsXml}
               </ItemGroup>
 
-              {rawXml}
+              {rawXmlText}
 
             </Project>
             """;
     }
 
-    public void Dispose() => ((IDisposable)_folder).Dispose();
+    public void Dispose() => ((IDisposable)folder).Dispose();
 }

--- a/src/Publicizer.Tests/Compiler.cs
+++ b/src/Publicizer.Tests/Compiler.cs
@@ -11,14 +11,14 @@ namespace Publicizer.Tests;
 /// </summary>
 internal static class Compiler
 {
-    private static readonly List<MetadataReference> s_references = BuildReferences();
+    private static readonly List<MetadataReference> references = BuildReferences();
 
     internal static byte[] Compile(string code, string assemblyName = "Fixture")
     {
         var compilation = CSharpCompilation.Create(
             assemblyName,
             [CSharpSyntaxTree.ParseText(code)],
-            s_references,
+            references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, deterministic: true));
 
         using var stream = new MemoryStream();

--- a/src/Publicizer.Tests/Fixtures.cs
+++ b/src/Publicizer.Tests/Fixtures.cs
@@ -69,20 +69,20 @@ internal static class Fixtures
         }
         """;
 
-    private static readonly byte[] s_shapesAssembly = Compiler.Compile(ShapesSource);
-    private static readonly Lazy<string> s_shapesFilePath = new(WriteShapesToDisk);
+    private static readonly byte[] shapesAssembly = Compiler.Compile(ShapesSource);
+    private static readonly Lazy<string> shapesFilePath = new(WriteShapesToDisk);
 
-    internal static ModuleDefMD LoadShapesModule() => ModuleDefMD.Load(s_shapesAssembly);
+    internal static ModuleDefMD LoadShapesModule() => ModuleDefMD.Load(shapesAssembly);
 
     // The task and the hasher work off a file path, so materialize the compiled bytes once as "Fixture.dll".
     // The filename (minus extension) is the assembly name the Publicize items match against.
-    internal static string ShapesPath() => s_shapesFilePath.Value;
+    internal static string ShapesPath() => shapesFilePath.Value;
 
     private static string WriteShapesToDisk()
     {
         string directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PublicizerFixtures")).FullName;
         string path = Path.Combine(directory, "Fixture.dll");
-        File.WriteAllBytes(path, s_shapesAssembly);
+        File.WriteAllBytes(path, shapesAssembly);
         return path;
     }
 }

--- a/src/Publicizer.Tests/GetPublicizerAssemblyContextsTests.cs
+++ b/src/Publicizer.Tests/GetPublicizerAssemblyContextsTests.cs
@@ -11,10 +11,7 @@ namespace Publicizer.Tests;
 /// </summary>
 internal static class GetPublicizerAssemblyContextsTests
 {
-    private static Dictionary<string, PublicizerAssemblyContext> Build(ITaskItem[] publicizes, ITaskItem[]? doNotPublicizes = null)
-    {
-        return PublicizeAssemblies.GetPublicizerAssemblyContexts(publicizes, doNotPublicizes ?? [], NullTaskLogger.Instance);
-    }
+    private static Dictionary<string, PublicizerAssemblyContext> Build(ITaskItem[] publicizes, ITaskItem[]? doNotPublicizes = null) => PublicizeAssemblies.GetPublicizerAssemblyContexts(publicizes, doNotPublicizes ?? [], NullTaskLogger.Instance);
 
     [Test]
     public static void AssemblyWidePublicize_SetsExplicitlyPublicizeAssemblyWithDefaults()

--- a/src/Publicizer.Tests/NullTaskLogger.cs
+++ b/src/Publicizer.Tests/NullTaskLogger.cs
@@ -3,7 +3,7 @@ namespace Publicizer.Tests;
 /// <summary>No-op <see cref="ITaskLogger"/> for exercising the engine directly.</summary>
 internal sealed class NullTaskLogger : ITaskLogger
 {
-    internal static readonly NullTaskLogger Instance = new();
+    internal static NullTaskLogger Instance { get; } = new();
 
     public void Error(string message) { }
     public void Warning(string message) { }

--- a/src/Publicizer.Tests/TemporaryFolder.cs
+++ b/src/Publicizer.Tests/TemporaryFolder.cs
@@ -12,13 +12,7 @@ internal sealed class TemporaryFolder : IDisposable
 
     internal string Path => _directoryInfo.FullName;
 
-    public override string ToString()
-    {
-        return _directoryInfo.FullName;
-    }
+    public override string ToString() => _directoryInfo.FullName;
 
-    void IDisposable.Dispose()
-    {
-        _directoryInfo.Delete(recursive: true);
-    }
+    void IDisposable.Dispose() => _directoryInfo.Delete(recursive: true);
 }

--- a/src/Publicizer.Tests/TemporaryFolder.cs
+++ b/src/Publicizer.Tests/TemporaryFolder.cs
@@ -2,17 +2,17 @@ namespace Publicizer.Tests;
 
 internal sealed class TemporaryFolder : IDisposable
 {
-    private readonly DirectoryInfo _directoryInfo;
+    private readonly DirectoryInfo directoryInfo;
     internal TemporaryFolder()
     {
         string path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
 
-        _directoryInfo = Directory.CreateDirectory(path);
+        directoryInfo = Directory.CreateDirectory(path);
     }
 
-    internal string Path => _directoryInfo.FullName;
+    internal string Path => directoryInfo.FullName;
 
-    public override string ToString() => _directoryInfo.FullName;
+    public override string ToString() => directoryInfo.FullName;
 
-    void IDisposable.Dispose() => _directoryInfo.Delete(recursive: true);
+    void IDisposable.Dispose() => directoryInfo.Delete(recursive: true);
 }

--- a/src/Publicizer/Hasher.cs
+++ b/src/Publicizer/Hasher.cs
@@ -12,7 +12,7 @@ internal static class Hasher
     // Includes the commit hash via SourceLink, so it changes on every build.
     // Feeding it into the cache key invalidates assemblies publicized by an
     // older Publicizer whose publicization logic may have differed.
-    private static readonly string s_publicizerVersion =
+    private static readonly string publicizerVersion =
         typeof(Hasher).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
@@ -21,7 +21,7 @@ internal static class Hasher
     internal static string ComputeHash(string assemblyPath, PublicizerAssemblyContext assemblyContext)
     {
         var sb = new StringBuilder();
-        sb.Append(s_publicizerVersion);
+        sb.Append(publicizerVersion);
         sb.Append(assemblyContext.AssemblyName);
         sb.Append(assemblyContext.IncludeCompilerGeneratedMembers);
         sb.Append(assemblyContext.IncludeVirtualMembers);

--- a/src/Publicizer/Logger.cs
+++ b/src/Publicizer/Logger.cs
@@ -65,18 +65,9 @@ internal sealed class Logger : ITaskLogger, IDisposable
         Write("VRB", message);
     }
 
-    private void Write(string logLevel, string message)
-    {
-        _logFileWriter.WriteLine($"[{Now} {logLevel}]{_scope} {message}");
-    }
+    private void Write(string logLevel, string message) => _logFileWriter.WriteLine($"[{Now} {logLevel}]{_scope} {message}");
 
-    internal ITaskLogger CreateScope(string assemblyName)
-    {
-        return new Logger(this, assemblyName);
-    }
+    internal ITaskLogger CreateScope(string assemblyName) => new Logger(this, assemblyName);
 
-    public void Dispose()
-    {
-        _logFileWriter.Dispose();
-    }
+    public void Dispose() => _logFileWriter.Dispose();
 }

--- a/src/Publicizer/Logger.cs
+++ b/src/Publicizer/Logger.cs
@@ -8,9 +8,9 @@ namespace Publicizer;
 /// </summary>
 internal sealed class Logger : ITaskLogger, IDisposable
 {
-    private readonly StreamWriter _logFileWriter = StreamWriter.Null;
-    private readonly TaskLoggingHelper _taskLogger;
-    private readonly string _scope;
+    private readonly StreamWriter logFileWriter = StreamWriter.Null;
+    private readonly TaskLoggingHelper taskLogger;
+    private readonly string scope;
 
     private static string Now => DateTime.Now.ToLongTimeString();
 
@@ -21,12 +21,12 @@ internal sealed class Logger : ITaskLogger, IDisposable
     /// <param name="stream">An arbitrary stream for writing logs to</param>
     internal Logger(TaskLoggingHelper taskLogger, Stream stream)
     {
-        _logFileWriter = new StreamWriter(stream)
+        logFileWriter = new StreamWriter(stream)
         {
             AutoFlush = true
         };
-        _taskLogger = taskLogger;
-        _scope = string.Empty;
+        this.taskLogger = taskLogger;
+        scope = string.Empty;
     }
 
     /// <summary>
@@ -36,38 +36,38 @@ internal sealed class Logger : ITaskLogger, IDisposable
     /// <param name="scope">A string representing the scope of the logger. This will be written to each log entry in the log file</param>
     private Logger(Logger parentLogger, string scope)
     {
-        _logFileWriter = parentLogger._logFileWriter;
-        _taskLogger = parentLogger._taskLogger;
-        _scope = $" [{scope}]";
+        logFileWriter = parentLogger.logFileWriter;
+        taskLogger = parentLogger.taskLogger;
+        this.scope = $" [{scope}]";
     }
 
     public void Error(string message)
     {
-        _taskLogger.LogError(message);
+        taskLogger.LogError(message);
         Write("ERR", message);
     }
 
     public void Warning(string message)
     {
-        _taskLogger.LogWarning(message);
+        taskLogger.LogWarning(message);
         Write("WRN", message);
     }
 
     public void Info(string message)
     {
-        _taskLogger.LogMessage(MessageImportance.Normal, message);
+        taskLogger.LogMessage(MessageImportance.Normal, message);
         Write("INF", message);
     }
 
     public void Verbose(string message)
     {
-        _taskLogger.LogMessage(MessageImportance.Low, message);
+        taskLogger.LogMessage(MessageImportance.Low, message);
         Write("VRB", message);
     }
 
-    private void Write(string logLevel, string message) => _logFileWriter.WriteLine($"[{Now} {logLevel}]{_scope} {message}");
+    private void Write(string logLevel, string message) => logFileWriter.WriteLine($"[{Now} {logLevel}]{scope} {message}");
 
     internal ITaskLogger CreateScope(string assemblyName) => new Logger(this, assemblyName);
 
-    public void Dispose() => _logFileWriter.Dispose();
+    public void Dispose() => logFileWriter.Dispose();
 }

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -490,8 +490,5 @@ public sealed class PublicizeAssemblies : Task
         return publicizedAnyMemberInAssembly;
     }
 
-    private static bool IsCompilerGenerated(IHasCustomAttribute memberDef)
-    {
-        return memberDef.CustomAttributes.Any(x => x.TypeFullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
-    }
+    private static bool IsCompilerGenerated(IHasCustomAttribute memberDef) => memberDef.CustomAttributes.Any(x => x.TypeFullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
 }

--- a/src/Publicizer/TaskItemExtensions.cs
+++ b/src/Publicizer/TaskItemExtensions.cs
@@ -5,15 +5,9 @@ namespace Publicizer;
 
 internal static class TaskItemExtensions
 {
-    internal static string FileName(this ITaskItem item)
-    {
-        return item.GetMetadata("Filename");
-    }
+    internal static string FileName(this ITaskItem item) => item.GetMetadata("Filename");
 
-    internal static string FullPath(this ITaskItem item)
-    {
-        return item.GetMetadata("Fullpath");
-    }
+    internal static string FullPath(this ITaskItem item) => item.GetMetadata("Fullpath");
 
     internal static bool IncludeCompilerGeneratedMembers(this ITaskItem item)
     {


### PR DESCRIPTION
266 lines to 67. Method: delete an entry, rebuild, see whether anything changes. Everything that survived is load-bearing.

**Removed because the blanket line already covers it.** `dotnet_analyzer_diagnostic.severity = warning` *does* enable rules that are off by default — with nothing but that one line present, CA1012, CA1822, IDE0011, IDE0044, IDE0051, IDE0055, IDE0059, IDE0060, IDE0160, IDE2000 and IDE2001 all fire. So the ~17 explicit `dotnet_diagnostic.*.severity = warning` entries were restating it.

**Removed because they restated a Roslyn default.** The entire spacing block (20 lines), the newline block, the indent block, the import-sorting pair, and every `= true:suggestion` preference whose value already matched the default.

**Removed because they no longer apply.** `CA1707` was suppressed for underscored test names, but the fixtures became `internal` in #229 and CA1707 only inspects externally visible identifiers. `IDE2003` had a severity set but its option never was, so it could not fire.

**Removed as policy nobody was enforcing.** The four `_allow_*_experimental` lines. Nothing in the repo violated them; they were forward-looking preference, and the file's contract now is that every line does work.

**Field prefixes are gone.** `s_` and `_` collapse into the locals rule, so one rule covers fields, locals and parameters. Four constructors and one method needed `this.` qualification where a parameter shadows a field, and three locals in `ToCsproj` were renamed to stop shadowing.

**Two rules are now satisfied rather than suppressed.** `csharp_style_expression_bodied_methods` was `false:none`, a blanket opt-out; it's now `when_on_single_line` with 11 single-statement methods converted. `NullTaskLogger.Instance` became a property — as an `internal static readonly` field it needed its own naming rule to exempt it.

**What's left:** the naming block, because Roslyn ships no naming rules at all. Drop the camelCase rule and 264 errors appear as fields and locals fall through to the PascalCase catch-all. Order matters — the catch-all goes last and the two rules above it exist to carve exceptions out of it. Then three preferences that differ from the default, and two deliberate opt-outs (IDE0058, 34 hits; IDE0046, 6 hits).

The four `[*.cs]` lines (indent, charset, final newline) are the one category where "does the build care?" is the wrong test — they're editor hints and the build ignores them. Kept on that basis. The XML/C# indent split is deliberate: 2 is MSBuild convention, 4 is C#, and the files already follow both.