### PR TITLE
Document publicization semantics

### DIFF
--- a/docs/publicization-semantics.md
+++ b/docs/publicization-semantics.md
@@ -77,7 +77,7 @@ Consequences worth naming explicitly:
 
 - **`DoNotPublicize` beats `Publicize` at the same specificity.** Naming a member in both excludes it (`MemberInBothPublicizeAndDoNotPublicize_DoNotPublicizeWins`).
 - **Specific beats general.** An explicit member `Publicize` overrides a type-wide or assembly-wide exclusion (`ExplicitMemberPublicize_BeatsDoNotPublicizeType`). This is what makes the README's "publicize specific ignored members" pattern work.
-- **Rule 3 bypasses all three filters.** An explicitly named member is publicized even if it is compiler-generated, even if it is virtual, and even if `MemberPattern` doesn't match it — `AssemblyEditor.PublicizeProperty`/`PublicizeMethod` are called with their `includeVirtual` default of `true` rather than the assembly's setting (`PublicizeAssemblies.cs:265`, `:329`, `ExplicitMemberPublicize_IgnoresIncludeVirtualMembers`).
+- **Rule 3 bypasses all three filters, by design.** An explicitly named member is publicized even if it is compiler-generated, even if it is virtual, and even if `MemberPattern` doesn't match it — `AssemblyEditor.PublicizeProperty`/`PublicizeMethod` are called with their `includeVirtual` default of `true` rather than the assembly's setting (`PublicizeAssemblies.cs:265`, `:329`, `ExplicitMemberPublicize_IgnoresIncludeVirtualMembers`). This is the documented escape hatch: the README's "you can still publicize specific ignored members by specifying them explicitly" pattern depends on it. Naming a member is treated as an unambiguous opt-in that outranks every blanket filter, so **a rewrite must preserve this** — removing it would silently un-publicize members for anyone following the documented pattern, surfacing as an unexplained CS0122.
 - **Excluding a property excludes its accessors.** Properties are processed before methods; excluding a property registers its getter and setter in a per-type set that the method loop consults first (`PublicizeAssemblies.cs:250-257`, `:313`). So `WholeAssembly_ExceptOneProperty_LeavesAccessorsUntouched` holds. Note the ordering: because rule 1 precedes rule 3, a `DoNotPublicize` on a property beats an explicit `Publicize` on one of its accessor methods by name.
 - **Filters do not compose as an OR.** With `MemberPattern` set *and* `IncludeCompilerGeneratedMembers="false"`, both must pass.
 
@@ -159,7 +159,7 @@ Collected here as rewrite input. None of these are bugs the current tests fail o
 1. Method targets cannot select an overload.
 2. Member names are matched by exact string, and the member kind is not part of the match, so a single target may hit several unrelated members.
 3. Events cannot be targeted; the backing-field name collision is the only handle, and it doesn't exist for events with explicit accessors.
-4. Explicit member targets silently ignore `IncludeVirtualMembers`, which can reintroduce the very override mismatch that flag exists to prevent.
+4. Explicit member targets bypass `IncludeVirtualMembers` intentionally, but because a target names *all* overloads at once, a target aimed at a non-virtual overload also publicizes a virtual one sharing the name — reintroducing the override mismatch the filter exists to prevent, without the user having opted into it for that member. This is a consequence of (1), not of the escape hatch itself, and overload-precise targeting would remove it.
 5. Assembly-form metadata is last-wins across duplicate items, without a diagnostic.
 6. Unparseable boolean metadata falls back to `true` instead of failing.
 7. A no-match target is silent.

--- a/docs/publicization-semantics.md
+++ b/docs/publicization-semantics.md
@@ -1,0 +1,142 @@
+# Publicization semantics
+
+This document describes what the current publicization engine actually does, member by member and rule by rule. It is a baseline: it records behavior as of today, including behavior that is accidental or undesirable, so that a future rewrite can decide deliberately what to preserve and what to change.
+
+It is not user documentation. The README is the user-facing contract; this describes the implementation's observable behavior, including corners the README doesn't mention.
+
+Every claim below is pinned by a test. Test names refer to `src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs` unless stated otherwise. The engine itself lives in `src/Publicizer/PublicizeAssemblies.cs` and `src/Publicizer/AssemblyEditor.cs`.
+
+## Targets
+
+A target is the `Include` value of a `Publicize` or `DoNotPublicize` item. It has two forms, distinguished by the presence of a colon:
+
+- `AssemblyName` — the assembly form.
+- `AssemblyName:MemberName` — the member form.
+
+The split happens at the **first** colon (`PublicizeAssemblies.cs:168`). Everything before it is the assembly name; everything after it, including any further colons, is the member name (`GetPublicizerAssemblyContextsTests.MemberSpec_SplitsOnFirstColonOnly`).
+
+Assemblies are identified by reference file name without extension, compared against the `Filename` metadata of each `ReferencePath`. Lookup is an ordinal dictionary lookup, so it is **case-sensitive** (`GetPublicizerAssemblyContextsTests.AssemblyNames_AreCaseSensitive`). A reference not named by any target is skipped untouched.
+
+### Member names
+
+Member names are matched by **exact string equality** against a `HashSet<string>` — despite the field being named `PublicizeMemberPatterns`, there is no globbing or wildcard matching in the member form. The strings compared against are:
+
+| Kind | String |
+|---|---|
+| Type | dnlib's `TypeDef.ReflectionFullName` |
+| Field | `{ReflectionFullName}.{FieldName}` |
+| Method | `{ReflectionFullName}.{MethodName}` |
+| Property | `{ReflectionFullName}.{PropertyName}` |
+
+This has direct consequences for the syntax users must write:
+
+- Nested types use `+`: `Fixture.Shapes+Inner` (`NestedMember_AlsoPublicizesEnclosingType`).
+- Generic types carry arity, backtick included: ``Fixture.GenericHolder`1.GenericField`` (`SingleMember_GenericField_MatchesArityMangledName`).
+- Constructors are `.ctor`, producing the doubled dot in `Fixture.Shapes..ctor` (`SingleMember_Constructor`).
+- Methods have no parameter list, so a target names *all* overloads at once. This is the single biggest limitation of the current model and the main motivation for a real parser.
+- Because names are compared without regard to member kind, one target string can match a type, a field, a method and a property simultaneously if they happen to share a name.
+
+### Events are not a member kind
+
+The engine iterates types, properties, methods and fields. It never iterates `TypeDef.Events`. An event therefore cannot be targeted as an event.
+
+It works anyway, by coincidence: a field-like event's compiler-generated backing field has the same name as the event, so `DoNotPublicize` on the event name matches the *field* and excludes it (`DoNotPublicizeEvent_ByName_ExcludesBackingField`). This is the documented workaround for issue #141, and it works only for field-like events — not for events with explicit `add`/`remove` accessors.
+
+### Assembly-form metadata
+
+Three metadata attributes are read, and **only from assembly-form items** (`PublicizeAssemblies.cs:178-185`):
+
+| Metadata | Default | Effect |
+|---|---|---|
+| `IncludeCompilerGeneratedMembers` | `true` | When false, skip anything carrying `[CompilerGenerated]` |
+| `IncludeVirtualMembers` | `true` | When false, skip virtual methods (and virtual property accessors) |
+| `MemberPattern` | none | Regex; a member is only publicized if the pattern matches its name string |
+
+Defaults apply when the metadata is absent *or unparseable* — `bool.TryParse` failure falls back to `true` rather than erroring (`TaskItemExtensions.cs:12-30`, `TaskItemExtensionsTests.IncludeCompilerGeneratedMembers_GarbageMetadata_DefaultsToTrue`), so `IncludeVirtualMembers="yes"` silently means `true`.
+
+Putting this metadata on a member-form item has no effect; it is read but never stored. `DoNotPublicize` items never read metadata at all.
+
+When several assembly-form `Publicize` items name the same assembly, the metadata of each **overwrites** the previous — last item wins, with no merge and no diagnostic. The overwrite is unconditional per field, so a later item that sets none of the metadata resets all of it to defaults, silently discarding an earlier item's `MemberPattern` (`GetPublicizerAssemblyContextsTests.DuplicateAssemblyWidePublicizes_LastMetadataWins`).
+
+The regex is applied to the same name strings listed above, and it is applied to types as well as members. It is unanchored, so `MemberPattern="Protected"` matches anywhere in the name (`WholeAssembly_WithMemberRegexPattern`).
+
+## Precedence
+
+For each field, method and property the engine walks a fixed decision ladder and stops at the first rule that applies (`PublicizeAssemblies.cs:243-428`, repeated near-identically for the three member kinds):
+
+1. **Accessor of an excluded property** (methods only) — skip.
+2. **`DoNotPublicize` names this member exactly** — skip.
+3. **`Publicize` names this member exactly** — publicize, ignoring every filter.
+4. **`DoNotPublicize` names the declaring type** — skip.
+5. **`DoNotPublicize` names the assembly** — skip.
+6. **`Publicize` names the assembly** — publicize, subject to the compiler-generated, regex and virtual filters.
+7. Otherwise — skip.
+
+Consequences worth naming explicitly:
+
+- **`DoNotPublicize` beats `Publicize` at the same specificity.** Naming a member in both excludes it (`MemberInBothPublicizeAndDoNotPublicize_DoNotPublicizeWins`).
+- **Specific beats general.** An explicit member `Publicize` overrides a type-wide or assembly-wide exclusion (`ExplicitMemberPublicize_BeatsDoNotPublicizeType`). This is what makes the README's "publicize specific ignored members" pattern work.
+- **Rule 3 bypasses all three filters.** An explicitly named member is publicized even if it is compiler-generated, even if it is virtual, and even if `MemberPattern` doesn't match it — `AssemblyEditor.PublicizeProperty`/`PublicizeMethod` are called with their `includeVirtual` default of `true` rather than the assembly's setting (`PublicizeAssemblies.cs:265`, `:329`, `ExplicitMemberPublicize_IgnoresIncludeVirtualMembers`).
+- **Excluding a property excludes its accessors.** Properties are processed before methods; excluding a property registers its getter and setter in a per-type set that the method loop consults first (`PublicizeAssemblies.cs:250-257`, `:313`). So `WholeAssembly_ExceptOneProperty_LeavesAccessorsUntouched` holds. Note the ordering: because rule 1 precedes rule 3, a `DoNotPublicize` on a property beats an explicit `Publicize` on one of its accessor methods by name.
+- **Filters do not compose as an OR.** With `MemberPattern` set *and* `IncludeCompilerGeneratedMembers="false"`, both must pass.
+
+## What publicizing does
+
+- **Field** — access bits cleared, `Public` set. Unconditional; `IncludeVirtualMembers` has no meaning for fields (`AssemblyEditor.cs:65`).
+- **Method** — access bits cleared, `Public` set, unless `includeVirtual` is false and the method is virtual, in which case nothing happens (`AssemblyEditor.cs:53`).
+- **Property** — the property itself has no accessibility in IL; publicizing one means publicizing its getter and setter, each subject to the virtual check (`AssemblyEditor.cs:36`).
+- **Type** — visibility bits cleared, then `Public` for a top-level type or `NestedPublic` for a nested one. The engine then **walks up the declaring-type chain** and does the same to every enclosing type, because a nested type is unreachable unless all its enclosers are too (`AssemblyEditor.cs:16`). Pinned by `PublicizeType_ByName_PublicizesTypeAndWalksUp` and `NestedMember_AlsoPublicizesEnclosingType`.
+
+Each of these returns whether it actually changed anything, so publicizing an already-public member reports no modification.
+
+### Types are publicized implicitly
+
+A type is publicized if **any** member in it was publicized, before the type's own rules are consulted (`PublicizeAssemblies.cs:430`). Only if no member was publicized does the engine evaluate the type against the ladder above.
+
+Because the implicit case short-circuits, it outranks the type's own exclusions:
+
+- A type named in `DoNotPublicize` still becomes public if an explicitly named member of it was publicized — though its other members stay untouched (`ExplicitMemberPublicize_BeatsDoNotPublicizeType`).
+- A type that the `MemberPattern` regex rejects still becomes public if one of its members matched.
+
+This is defensible — a publicized member is useless in an inaccessible type — but it means "do not publicize this type" does not guarantee the type's accessibility is preserved.
+
+## Whole-assembly behavior
+
+`Publicize Include="MyAssembly"` with no member targets publicizes every type and every member subject to the filters (`WholeAssembly_Defaults`). Notable interactions:
+
+- `IncludeVirtualMembers="false"` leaves virtual methods and virtual property accessors alone but does not affect fields or types (`WholeAssembly_ExcludingVirtualMembers`).
+- `IncludeCompilerGeneratedMembers="false"` skips anything with `[CompilerGenerated]`, which is what keeps event backing fields private and avoids the CS0229 collision that motivated the flag in issue #9 (`WholeAssembly_ExcludingCompilerGeneratedMembers`, `EventBackingField_WholeAssemblyDefault_BecomesPublic_TheCollision`, `EventBackingField_ExcludingCompilerGenerated_StaysPrivate`). The check looks only for that one attribute by full name; it does not recognise other compiler conventions such as `<>`-mangled names.
+- `DoNotPublicize Include="MyAssembly"` suppresses the whole-assembly sweep but does not suppress explicit member targets (`DoNotPublicizeAssembly_PublicizesNothing` covers the sweep; rule 3 above covers the exception).
+
+## Diagnostics
+
+The engine is quiet by design, which the rewrite intends to change:
+
+- A target that matches nothing produces **no diagnostic at all** (`PublicizeTarget_MatchesNothing_PublicizesNothingAndReturnsFalse`). Typos in a member name are silent.
+- If an assembly is targeted but nothing in it was publicized, a warning is logged and the reference is left pointing at the original assembly (`PublicizeAssemblies.cs:115`).
+- A `DoNotPublicize` naming an assembly that no `Publicize` mentions creates a context anyway, so the assembly is processed, publicizes nothing, and warns.
+- Everything else is informational logging, optionally mirrored to `PublicizerLogFilePath`.
+
+## Outside the decision tree
+
+For completeness, behavior that surrounds publicization but isn't part of the matching rules:
+
+- **Caching.** Output goes to `{OutputDirectory}/{assembly}.{hash}/{assembly}.dll`, where the hash covers the input assembly bytes, the resolved context, and Publicizer's own informational version (`Hasher.cs`). If that path exists, the assembly is not reprocessed. Changing any target therefore changes the path rather than invalidating in place.
+- **XML documentation** next to the input assembly is copied alongside the output (`PublicizeAssemblies.cs:132-141`).
+- **Writer options** set `KeepOldMaxStack`, because writing some assemblies fails otherwise (issue #42).
+- **Reference swapping.** Processed references are reported on `ReferencePathsToDelete`/`ReferencePathsToAdd`, with metadata copied to the new item, and the targets file performs the substitution.
+
+## Known-questionable behavior
+
+Collected here as rewrite input. None of these are bugs the current tests fail on; they are the places where the current model and a reasonable model diverge.
+
+1. Method targets cannot select an overload.
+2. Member names are matched by exact string, and the member kind is not part of the match, so a single target may hit several unrelated members.
+3. Events cannot be targeted; the backing-field name collision is the only handle, and it doesn't exist for events with explicit accessors.
+4. Explicit member targets silently ignore `IncludeVirtualMembers`, which can reintroduce the very override mismatch that flag exists to prevent.
+5. Assembly-form metadata is last-wins across duplicate items, without a diagnostic.
+6. Unparseable boolean metadata falls back to `true` instead of failing.
+7. A no-match target is silent.
+8. Assembly name matching is case-sensitive, which is surprising on Windows.
+9. `DoNotPublicize` on a type does not prevent that type from being made public via an explicitly targeted member.
+10. `DoNotPublicize` on a type does not extend to its nested types; each nested type has its own reflection name and must be named separately (`DoNotPublicizeType_DoesNotExtendToNestedTypes`).

--- a/docs/publicization-semantics.md
+++ b/docs/publicization-semantics.md
@@ -32,7 +32,8 @@ This has direct consequences for the syntax users must write:
 
 - Nested types use `+`: `Fixture.Shapes+Inner` (`NestedMember_AlsoPublicizesEnclosingType`).
 - Generic types carry arity, backtick included: ``Fixture.GenericHolder`1.GenericField`` (`SingleMember_GenericField_MatchesArityMangledName`).
-- Constructors are `.ctor`, producing the doubled dot in `Fixture.Shapes..ctor` (`SingleMember_Constructor`).
+- Constructors are `.ctor`, producing the doubled dot in `Fixture.Shapes..ctor` (`SingleMember_Constructor`). Static constructors are `.cctor`.
+- Types in the global namespace have no prefix at all: `GlobalType.someField` (`SignatureClosureTests.GlobalNamespaceType_IsNamedWithoutNamespacePrefix`, issue #14).
 - Methods have no parameter list, so a target names *all* overloads at once. This is the single biggest limitation of the current model and the main motivation for a real parser.
 - Because names are compared without regard to member kind, one target string can match a type, a field, a method and a property simultaneously if they happen to share a name.
 
@@ -54,7 +55,7 @@ Three metadata attributes are read, and **only from assembly-form items** (`Publ
 
 Defaults apply when the metadata is absent *or unparseable* — `bool.TryParse` failure falls back to `true` rather than erroring (`TaskItemExtensions.cs:12-30`, `TaskItemExtensionsTests.IncludeCompilerGeneratedMembers_GarbageMetadata_DefaultsToTrue`), so `IncludeVirtualMembers="yes"` silently means `true`.
 
-Putting this metadata on a member-form item has no effect; it is read but never stored. `DoNotPublicize` items never read metadata at all.
+Putting this metadata on a member-form item has no effect; it is read but never stored. `DoNotPublicize` items never read metadata at all. This asymmetry is a known wart — it was raised while designing the "publicize a whole type" feature (issue #100), and is why that feature shipped as assembly-level `MemberPattern` rather than a type-level `IncludeMembers`. Consequently **the only way to publicize all members of one type is a regex** anchored on the type name.
 
 When several assembly-form `Publicize` items name the same assembly, the metadata of each **overwrites** the previous — last item wins, with no merge and no diagnostic. The overwrite is unconditional per field, so a later item that sets none of the metadata resets all of it to defaults, silently discarding an earlier item's `MemberPattern` (`GetPublicizerAssemblyContextsTests.DuplicateAssemblyWidePublicizes_LastMetadataWins`).
 
@@ -126,6 +127,31 @@ For completeness, behavior that surrounds publicization but isn't part of the ma
 - **Writer options** set `KeepOldMaxStack`, because writing some assemblies fails otherwise (issue #42).
 - **Reference swapping.** Processed references are reported on `ReferencePathsToDelete`/`ReferencePathsToAdd`, with metadata copied to the new item, and the targets file performs the substitution.
 
+## Publicization does not close over dependencies
+
+Publicization changes the accessibility of the members it matches by name, and nothing else. It never inspects a member's signature. The only transitive rule in the engine is the declaring-type walk-up for nested types (`AssemblyEditor.cs:16`).
+
+So a member can become public and still be unusable:
+
+- A method whose **parameter** type is internal or private becomes public but stays uncallable — the caller cannot name a value to pass (`SignatureClosureTests.PublicizingMethod_DoesNotPublicizeItsParameterTypes`).
+- A method whose **return** type is inaccessible is survivable via `var`, but the type still can't be named in a field, a cast, or a generic argument (`PublicizingMethod_DoesNotPublicizeItsReturnType`).
+- A **field** of an inaccessible type has the same problem (`PublicizingField_DoesNotPublicizeItsFieldType`).
+- Generic constraints, base types and interfaces are equally untouched.
+
+This has gone largely unreported because **whole-assembly publicization closes over everything by accident** — if every type is public, no signature can reference an inaccessible one (`WholeAssembly_ClosesOverSignatureTypesByAccident`). The gap only bites targeted publicization, which is the minority use case today and the mode a structured-matcher rewrite is meant to make attractive. Anything that makes targeting more precise makes this more visible.
+
+Whether to close over signatures automatically is a genuine design question, not an obvious fix: the transitive closure of a single method can drag in a large share of an assembly, and silently publicizing types the user didn't name is its own surprise. Options worth weighing are doing nothing (status quo), warning when a publicized member's signature references a type that stays inaccessible, or an opt-in closure mode.
+
+## Type-identity scenarios that are out of scope
+
+These are recurring support questions where the semantics are working as designed and the problem lies outside the decision tree. Documented so a rewrite doesn't mistake them for bugs to fix.
+
+- **The publicized assembly is a compile-time substitute only.** The runtime loads the *original*. Everything in the README's "Quirks" section follows from this, and so does the override mismatch that `IncludeVirtualMembers` exists to work around (issue #72 proposed rewriting subclass overrides to compensate; declined as more ambitious than it's worth).
+- **Reference assemblies publicize fine but decompile poorly**, because method bodies are already stripped before Publicizer sees them (issue #63).
+- **Targets are matched against the assembly on disk that the project actually references**, which may not be the one the user is reading in a decompiler. Issue #175 is entirely this: `Dictionary` fields named `_buckets` vs `buckets` because the reference package was built from .NET Core rather than Framework. No engine change can help; a diagnostic naming the resolved path might.
+- **Runtime-implementation assemblies can't be targeted unless the project references them.** `System.Private.CoreLib` is reached through `System.Runtime`, which is what the project references and therefore all that can be publicized (issue #101; the reporter's workaround was to author a stub reference assembly of the same name).
+- **`IgnoresAccessChecksToAttribute` can collide** with another definition in the compilation, e.g. MonoMod.Utils, producing CS0436 (issue #163). This is the runtime strategy, not publicization.
+
 ## Known-questionable behavior
 
 Collected here as rewrite input. None of these are bugs the current tests fail on; they are the places where the current model and a reasonable model diverge.
@@ -140,3 +166,5 @@ Collected here as rewrite input. None of these are bugs the current tests fail o
 8. Assembly name matching is case-sensitive, which is surprising on Windows.
 9. `DoNotPublicize` on a type does not prevent that type from being made public via an explicitly targeted member.
 10. `DoNotPublicize` on a type does not extend to its nested types; each nested type has its own reflection name and must be named separately (`DoNotPublicizeType_DoesNotExtendToNestedTypes`).
+11. Publicization does not close over signature types, so targeted publicization can produce public-but-unusable members.
+12. Per-item options only exist on the assembly form, so "all members of this type" is only expressible as a regex.

--- a/src/Publicizer.Tests/GetPublicizerAssemblyContextsTests.cs
+++ b/src/Publicizer.Tests/GetPublicizerAssemblyContextsTests.cs
@@ -87,4 +87,37 @@ internal static class GetPublicizerAssemblyContextsTests
         Assert.That(context.ExplicitlyPublicizeAssembly, Is.True);
         Assert.That(context.DoNotPublicizeMemberPatterns, Does.Contain("Ns.Type.Member"));
     }
+
+    [Test]
+    public static void MemberSpec_SplitsOnFirstColonOnly()
+    {
+        Dictionary<string, PublicizerAssemblyContext> contexts = Build([new TaskItem("Asm:Ns.Type.Member:Extra")]);
+
+        Assert.That(contexts["Asm"].PublicizeMemberPatterns, Does.Contain("Ns.Type.Member:Extra"));
+    }
+
+    [Test]
+    public static void AssemblyNames_AreCaseSensitive()
+    {
+        Dictionary<string, PublicizerAssemblyContext> contexts = Build([new TaskItem("Asm"), new TaskItem("ASM")]);
+
+        Assert.That(contexts, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public static void DuplicateAssemblyWidePublicizes_LastMetadataWins()
+    {
+        var first = new TaskItem("Asm");
+        first.SetMetadata("IncludeVirtualMembers", "false");
+        first.SetMetadata("MemberPattern", ".*First.*");
+        var second = new TaskItem("Asm");
+        second.SetMetadata("IncludeVirtualMembers", "true");
+
+        PublicizerAssemblyContext context = Build([first, second])["Asm"];
+
+        // The second item overwrites every metadata-derived field, including the ones it does not set,
+        // because each is assigned unconditionally rather than merged.
+        Assert.That(context.IncludeVirtualMembers, Is.True);
+        Assert.That(context.PublicizeMemberRegexPattern, Is.Null);
+    }
 }

--- a/src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs
+++ b/src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs
@@ -307,7 +307,8 @@ internal static partial class PublicizeAssemblyCharacterizationTests
         Publicize(module, context);
 
         // The explicit path publicizes with includeVirtual defaulted to true rather than the assembly's
-        // setting, so naming a virtual member reintroduces the override mismatch the flag exists to avoid.
+        // setting. This is the documented escape hatch (README: "you can still publicize specific ignored
+        // members by specifying them explicitly") - naming a member outranks every blanket filter.
         Assert.That(Method(module, "Fixture.Shapes", "ProtectedVirtualMethod").IsPublic, Is.True);
         // Virtual members not named explicitly still honor the flag.
         Assert.That(Method(module, "Fixture.Shapes", "ProtectedAbstractMethod").IsFamily, Is.True);

--- a/src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs
+++ b/src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs
@@ -20,6 +20,9 @@ internal static partial class PublicizeAssemblyCharacterizationTests
     private static FieldDef Field(ModuleDef module, string typeReflectionName, string fieldName) =>
         module.Find(typeReflectionName, isReflectionName: true).Fields.Single(f => f.Name == fieldName);
 
+    private static MethodDef Method(ModuleDef module, string typeReflectionName, string methodName) =>
+        module.Find(typeReflectionName, isReflectionName: true).Methods.Single(m => m.Name == methodName);
+
     [Test]
     public static void WholeAssembly_Defaults()
     {
@@ -288,5 +291,39 @@ internal static partial class PublicizeAssemblyCharacterizationTests
         Assert.That(Field(module, "Fixture.Shapes", "FieldLikeEvent").IsPrivate, Is.True);
         // The rest of the assembly is still publicized.
         Assert.That(Field(module, "Fixture.Shapes", "PrivateField").IsPublic, Is.True);
+    }
+
+    [Test]
+    public static void ExplicitMemberPublicize_IgnoresIncludeVirtualMembers()
+    {
+        using ModuleDefMD module = Fixtures.LoadShapesModule();
+        var context = new PublicizerAssemblyContext("Fixture")
+        {
+            ExplicitlyPublicizeAssembly = true,
+            IncludeVirtualMembers = false,
+        };
+        context.PublicizeMemberPatterns.Add("Fixture.Shapes.ProtectedVirtualMethod");
+
+        Publicize(module, context);
+
+        // The explicit path publicizes with includeVirtual defaulted to true rather than the assembly's
+        // setting, so naming a virtual member reintroduces the override mismatch the flag exists to avoid.
+        Assert.That(Method(module, "Fixture.Shapes", "ProtectedVirtualMethod").IsPublic, Is.True);
+        // Virtual members not named explicitly still honor the flag.
+        Assert.That(Method(module, "Fixture.Shapes", "ProtectedAbstractMethod").IsFamily, Is.True);
+    }
+
+    [Test]
+    public static void DoNotPublicizeType_DoesNotExtendToNestedTypes()
+    {
+        using ModuleDefMD module = Fixtures.LoadShapesModule();
+        var context = new PublicizerAssemblyContext("Fixture") { ExplicitlyPublicizeAssembly = true };
+        context.DoNotPublicizeMemberPatterns.Add("Fixture.Shapes");
+
+        Publicize(module, context);
+
+        // A nested type has its own reflection name, so excluding the enclosing type leaves it publicized.
+        Assert.That(Field(module, "Fixture.Shapes", "PrivateField").IsPrivate, Is.True);
+        Assert.That(Field(module, "Fixture.Shapes+Inner", "InnerPrivateField").IsPublic, Is.True);
     }
 }

--- a/src/Publicizer.Tests/SignatureClosureTests.cs
+++ b/src/Publicizer.Tests/SignatureClosureTests.cs
@@ -1,0 +1,112 @@
+using dnlib.DotNet;
+using NUnit.Framework;
+
+namespace Publicizer.Tests;
+
+/// <summary>
+/// Characterizes what publicization does *not* do: it changes the accessibility of the members it
+/// matches by name, and nothing else. Types appearing in a publicized member's signature are not
+/// pulled along, so a member can become public while remaining unusable from consuming code.
+/// Uses its own fixture rather than the shared one so these shapes don't churn every snapshot.
+/// </summary>
+internal static class SignatureClosureTests
+{
+    // A public type whose private members traffic in types the consumer cannot name, plus a
+    // global-namespace type (issue #14) whose reflection name carries no namespace prefix.
+    private const string ClosureSource =
+        """
+        internal class GlobalHiddenType
+        {
+            private int GlobalPrivateField;
+        }
+
+        namespace Fixture
+        {
+            internal class HiddenType { }
+
+            public class Api
+            {
+                private HiddenType ReturnsHidden() => new HiddenType();
+                private void TakesHidden(HiddenType hidden) { }
+                private HiddenType HiddenField;
+            }
+        }
+        """;
+
+    private static readonly byte[] closureAssembly = Compiler.Compile(ClosureSource, "Closure");
+
+    private static ModuleDefMD LoadClosureModule() => ModuleDefMD.Load(closureAssembly);
+
+    private static TypeDef Type(ModuleDef module, string reflectionName) => module.Find(reflectionName, isReflectionName: true);
+
+    private static MethodDef Method(ModuleDef module, string typeReflectionName, string methodName) =>
+        Type(module, typeReflectionName).Methods.Single(m => m.Name == methodName);
+
+    private static void Publicize(ModuleDef module, PublicizerAssemblyContext context) => PublicizeAssemblies.PublicizeAssembly(module, context, NullTaskLogger.Instance);
+
+    [Test]
+    public static void PublicizingMethod_DoesNotPublicizeItsReturnType()
+    {
+        using ModuleDefMD module = LoadClosureModule();
+        var context = new PublicizerAssemblyContext("Closure");
+        context.PublicizeMemberPatterns.Add("Fixture.Api.ReturnsHidden");
+
+        Publicize(module, context);
+
+        Assert.That(Method(module, "Fixture.Api", "ReturnsHidden").IsPublic, Is.True);
+        // The return type stays internal. Callers can still use `var`, so this one is survivable.
+        Assert.That(Type(module, "Fixture.HiddenType").IsNotPublic, Is.True);
+    }
+
+    [Test]
+    public static void PublicizingMethod_DoesNotPublicizeItsParameterTypes()
+    {
+        using ModuleDefMD module = LoadClosureModule();
+        var context = new PublicizerAssemblyContext("Closure");
+        context.PublicizeMemberPatterns.Add("Fixture.Api.TakesHidden");
+
+        Publicize(module, context);
+
+        // The method is public but uncallable: the caller cannot name a value of the parameter type.
+        Assert.That(Method(module, "Fixture.Api", "TakesHidden").IsPublic, Is.True);
+        Assert.That(Type(module, "Fixture.HiddenType").IsNotPublic, Is.True);
+    }
+
+    [Test]
+    public static void PublicizingField_DoesNotPublicizeItsFieldType()
+    {
+        using ModuleDefMD module = LoadClosureModule();
+        var context = new PublicizerAssemblyContext("Closure");
+        context.PublicizeMemberPatterns.Add("Fixture.Api.HiddenField");
+
+        Publicize(module, context);
+
+        Assert.That(Type(module, "Fixture.Api").Fields.Single(f => f.Name == "HiddenField").IsPublic, Is.True);
+        Assert.That(Type(module, "Fixture.HiddenType").IsNotPublic, Is.True);
+    }
+
+    [Test]
+    public static void WholeAssembly_ClosesOverSignatureTypesByAccident()
+    {
+        using ModuleDefMD module = LoadClosureModule();
+        var context = new PublicizerAssemblyContext("Closure") { ExplicitlyPublicizeAssembly = true };
+
+        Publicize(module, context);
+
+        // Whole-assembly mode has no closure problem because it publicizes everything anyway.
+        // The gap only bites targeted publicization, which is why it has gone largely unreported.
+        Assert.That(Type(module, "Fixture.HiddenType").IsPublic, Is.True);
+    }
+
+    [Test]
+    public static void GlobalNamespaceType_IsNamedWithoutNamespacePrefix()
+    {
+        using ModuleDefMD module = LoadClosureModule();
+        var context = new PublicizerAssemblyContext("Closure");
+        context.PublicizeMemberPatterns.Add("GlobalHiddenType.GlobalPrivateField");
+
+        Publicize(module, context);
+
+        Assert.That(Type(module, "GlobalHiddenType").Fields.Single(f => f.Name == "GlobalPrivateField").IsPublic, Is.True);
+    }
+}


### PR DESCRIPTION
Baseline documentation for the engine rewrite: `docs/publicization-semantics.md` describes what the current decision tree actually does — target grammar, member-name matching, the precedence ladder, and what publicizing each member kind changes.

It deliberately records the accidental behavior too, so the rewrite can decide what to preserve rather than rediscover it. Each claim cites the test that pins it, and the last section collects the known-questionable behavior as rewrite input.

Two sections go beyond the decision tree:

- **Dependency closure.** Publicization never inspects signatures, so a targeted publicize can make a method public that no caller can invoke, because its parameter type stays internal. Whole-assembly mode closes over this by accident, which is why it's largely unreported — but it's exactly the mode a structured-matcher rewrite is meant to make attractive.
- **Out-of-scope type-identity scenarios**, drawn from closed issues (#63, #72, #101, #163, #175), so a rewrite doesn't mistake working-as-designed support questions for bugs.

Ten claims weren't pinned by anything, so this adds tests for them. All pass against current behavior; none are fixes.

Not user documentation — the README remains the user-facing contract.