### PR TITLE
Collapse publicization ladders into one matcher

### DIFF
--- a/docs/publicization-semantics.md
+++ b/docs/publicization-semantics.md
@@ -4,7 +4,7 @@ This document describes what the current publicization engine actually does, mem
 
 It is not user documentation. The README is the user-facing contract; this describes the implementation's observable behavior, including corners the README doesn't mention.
 
-Every claim below is pinned by a test. Test names refer to `src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs` unless stated otherwise. The engine itself lives in `src/Publicizer/PublicizeAssemblies.cs` and `src/Publicizer/AssemblyEditor.cs`.
+Every claim below is pinned by a test. Test names refer to `src/Publicizer.Tests/PublicizeAssemblyCharacterizationTests.cs` unless stated otherwise. The engine itself lives in `src/Publicizer/PublicizeAssemblies.cs` (traversal and edits), `src/Publicizer/AssemblyPlan.cs` and `src/Publicizer/TypePlan.cs` (which target matches what), and `src/Publicizer/AssemblyEditor.cs` (what publicizing does).
 
 ## Targets
 
@@ -13,13 +13,13 @@ A target is the `Include` value of a `Publicize` or `DoNotPublicize` item. It ha
 - `AssemblyName` — the assembly form.
 - `AssemblyName:MemberName` — the member form.
 
-The split happens at the **first** colon (`PublicizeAssemblies.cs:168`). Everything before it is the assembly name; everything after it, including any further colons, is the member name (`GetPublicizerAssemblyContextsTests.MemberSpec_SplitsOnFirstColonOnly`).
+The split happens at the **first** colon (`PublicizeAssemblies.cs:172`). Everything before it is the assembly name; everything after it, including any further colons, is the member name (`GetPublicizerAssemblyContextsTests.MemberSpec_SplitsOnFirstColonOnly`).
 
 Assemblies are identified by reference file name without extension, compared against the `Filename` metadata of each `ReferencePath`. Lookup is an ordinal dictionary lookup, so it is **case-sensitive** (`GetPublicizerAssemblyContextsTests.AssemblyNames_AreCaseSensitive`). A reference not named by any target is skipped untouched.
 
 ### Member names
 
-Member names are matched by **exact string equality** against a `HashSet<string>` — despite the field being named `PublicizeMemberPatterns`, there is no globbing or wildcard matching in the member form. The strings compared against are:
+Member names are matched by **exact string equality** — despite the field being named `PublicizeMemberPatterns`, there is no globbing or wildcard matching in the member form. The strings compared against are:
 
 | Kind | String |
 |---|---|
@@ -37,6 +37,8 @@ This has direct consequences for the syntax users must write:
 - Methods have no parameter list, so a target names *all* overloads at once. This is the single biggest limitation of the current model and the main motivation for a real parser.
 - Because names are compared without regard to member kind, one target string can match a type, a field, a method and a property simultaneously if they happen to share a name.
 
+The comparison is not literally a lookup of the concatenated name. `AssemblyPlan` decomposes each target once, up front, into every `(type, member)` pair it could denote, so deciding a member is a per-type set lookup rather than a rebuilt string. The target is genuinely ambiguous — `A.B.C` may name a type, or member `C` of type `A.B`, and the syntax offers no way to say which — so it is indexed under *every* split point rather than resolved to one reading. That is equivalent to the string comparison it describes, including the doubled dot of `Fixture.Shapes..ctor`, which a split at the last dot would get wrong.
+
 ### Events are not a member kind
 
 The engine iterates types, properties, methods and fields. It never iterates `TypeDef.Events`. An event therefore cannot be targeted as an event.
@@ -45,7 +47,7 @@ It works anyway, by coincidence: a field-like event's compiler-generated backing
 
 ### Assembly-form metadata
 
-Three metadata attributes are read, and **only from assembly-form items** (`PublicizeAssemblies.cs:178-185`):
+Three metadata attributes are read, and **only from assembly-form items** (`PublicizeAssemblies.cs:184-187`):
 
 | Metadata | Default | Effect |
 |---|---|---|
@@ -63,7 +65,7 @@ The regex is applied to the same name strings listed above, and it is applied to
 
 ## Precedence
 
-For each field, method and property the engine walks a fixed decision ladder and stops at the first rule that applies (`PublicizeAssemblies.cs:243-428`, repeated near-identically for the three member kinds):
+For each field, method and property the engine walks a fixed decision ladder and stops at the first rule that applies (`TypePlan.DecideMember`, with the type's own tail in `TypePlan.DecideType`):
 
 1. **Accessor of an excluded property** (methods only) — skip.
 2. **`DoNotPublicize` names this member exactly** — skip.
@@ -77,8 +79,8 @@ Consequences worth naming explicitly:
 
 - **`DoNotPublicize` beats `Publicize` at the same specificity.** Naming a member in both excludes it (`MemberInBothPublicizeAndDoNotPublicize_DoNotPublicizeWins`).
 - **Specific beats general.** An explicit member `Publicize` overrides a type-wide or assembly-wide exclusion (`ExplicitMemberPublicize_BeatsDoNotPublicizeType`). This is what makes the README's "publicize specific ignored members" pattern work.
-- **Rule 3 bypasses all three filters, by design.** An explicitly named member is publicized even if it is compiler-generated, even if it is virtual, and even if `MemberPattern` doesn't match it — `AssemblyEditor.PublicizeProperty`/`PublicizeMethod` are called with their `includeVirtual` default of `true` rather than the assembly's setting (`PublicizeAssemblies.cs:265`, `:329`, `ExplicitMemberPublicize_IgnoresIncludeVirtualMembers`). This is the documented escape hatch: the README's "you can still publicize specific ignored members by specifying them explicitly" pattern depends on it. Naming a member is treated as an unambiguous opt-in that outranks every blanket filter, so **a rewrite must preserve this** — removing it would silently un-publicize members for anyone following the documented pattern, surfacing as an unexplained CS0122.
-- **Excluding a property excludes its accessors.** Properties are processed before methods; excluding a property registers its getter and setter in a per-type set that the method loop consults first (`PublicizeAssemblies.cs:250-257`, `:313`). So `WholeAssembly_ExceptOneProperty_LeavesAccessorsUntouched` holds. Note the ordering: because rule 1 precedes rule 3, a `DoNotPublicize` on a property beats an explicit `Publicize` on one of its accessor methods by name.
+- **Rule 3 bypasses all three filters, by design.** An explicitly named member is publicized even if it is compiler-generated, even if it is virtual, and even if `MemberPattern` doesn't match it — the ladder reports such a hit as `PublicizeDecision.Explicit`, and the walk then calls `AssemblyEditor.PublicizeProperty`/`PublicizeMethod` with `includeVirtual: true` rather than the assembly's setting (`ExplicitMemberPublicize_IgnoresIncludeVirtualMembers`). This is the documented escape hatch: the README's "you can still publicize specific ignored members by specifying them explicitly" pattern depends on it. Naming a member is treated as an unambiguous opt-in that outranks every blanket filter, so **a rewrite must preserve this** — removing it would silently un-publicize members for anyone following the documented pattern, surfacing as an unexplained CS0122.
+- **Excluding a property excludes its accessors.** Properties are processed before methods; a `PublicizeDecision.DeniedExplicitly` on a property registers its getter and setter in a per-type set that the method loop consults first. So `WholeAssembly_ExceptOneProperty_LeavesAccessorsUntouched` holds. Note the ordering: because rule 1 precedes rule 3, a `DoNotPublicize` on a property beats an explicit `Publicize` on one of its accessor methods by name.
 - **Filters do not compose as an OR.** With `MemberPattern` set *and* `IncludeCompilerGeneratedMembers="false"`, both must pass.
 
 ## What publicizing does
@@ -92,7 +94,7 @@ Each of these returns whether it actually changed anything, so publicizing an al
 
 ### Types are publicized implicitly
 
-A type is publicized if **any** member in it was publicized, before the type's own rules are consulted (`PublicizeAssemblies.cs:430`). Only if no member was publicized does the engine evaluate the type against the ladder above.
+A type is publicized if **any** member in it was publicized, before the type's own rules are consulted. This short-circuit lives in the walk, not in the matcher. Only if no member was publicized does the engine evaluate the type against the ladder above.
 
 Because the implicit case short-circuits, it outranks the type's own exclusions:
 
@@ -123,7 +125,7 @@ The engine is quiet by design, which the rewrite intends to change:
 For completeness, behavior that surrounds publicization but isn't part of the matching rules:
 
 - **Caching.** Output goes to `{OutputDirectory}/{assembly}.{hash}/{assembly}.dll`, where the hash covers the input assembly bytes, the resolved context, and Publicizer's own informational version (`Hasher.cs`). If that path exists, the assembly is not reprocessed. Changing any target therefore changes the path rather than invalidating in place.
-- **XML documentation** next to the input assembly is copied alongside the output (`PublicizeAssemblies.cs:132-141`).
+- **XML documentation** next to the input assembly is copied alongside the output (`PublicizeAssemblies.cs:135-144`).
 - **Writer options** set `KeepOldMaxStack`, because writing some assemblies fails otherwise (issue #42).
 - **Reference swapping.** Processed references are reported on `ReferencePathsToDelete`/`ReferencePathsToAdd`, with metadata copied to the new item, and the targets file performs the substitution.
 

--- a/src/Publicizer.Tests/AssemblyPlanTests.cs
+++ b/src/Publicizer.Tests/AssemblyPlanTests.cs
@@ -1,0 +1,201 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Publicizer.Tests;
+
+/// <summary>
+/// Covers <see cref="AssemblyPlan"/> and <see cref="TypePlan"/>: the compiled form of a
+/// <see cref="PublicizerAssemblyContext"/>, and the single decision ladder the member walk runs.
+/// The ladder itself is pinned end-to-end by <see cref="PublicizeAssemblyCharacterizationTests"/>;
+/// these tests exercise the rungs directly, without dnlib.
+/// </summary>
+internal static partial class AssemblyPlanTests
+{
+    [GeneratedRegex("Visible")]
+    private static partial Regex VisiblePattern();
+
+    private static TypePlan ForType(PublicizerAssemblyContext context, string typeName)
+    {
+        TypePlan? typePlan = AssemblyPlan.Compile(context).ForType(typeName);
+        Assert.That(typePlan, Is.Not.Null, $"expected a plan for {typeName}");
+        return typePlan!;
+    }
+
+    private static PublicizerAssemblyContext SweepAll() =>
+        new("Asm") { ExplicitlyPublicizeAssembly = true };
+
+    [Test]
+    public static void ForType_NoRuleCanReachType_ReturnsNull()
+    {
+        var context = new PublicizerAssemblyContext("Asm");
+        context.PublicizeMemberPatterns.Add("Ns.Other.Member");
+
+        Assert.That(AssemblyPlan.Compile(context).ForType("Ns.Type"), Is.Null);
+    }
+
+    [Test]
+    public static void ForType_DoNotPublicizeAssemblyWithNoNamedTargets_ReturnsNull()
+    {
+        var context = new PublicizerAssemblyContext("Asm") { ExplicitlyDoNotPublicizeAssembly = true };
+
+        Assert.That(AssemblyPlan.Compile(context).ForType("Ns.Type"), Is.Null);
+    }
+
+    [Test]
+    public static void ForType_NamedTargetSurvivesDoNotPublicizeAssembly()
+    {
+        var context = new PublicizerAssemblyContext("Asm") { ExplicitlyDoNotPublicizeAssembly = true };
+        context.PublicizeMemberPatterns.Add("Ns.Type.Member");
+
+        TypePlan typePlan = ForType(context, "Ns.Type");
+
+        Assert.That(typePlan.DecideMember("Member", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Explicit));
+    }
+
+    [Test]
+    public static void DecideMember_DoNotPublicizeBeatsPublicizeAtSameSpecificity()
+    {
+        PublicizerAssemblyContext context = SweepAll();
+        context.PublicizeMemberPatterns.Add("Ns.Type.Member");
+        context.DoNotPublicizeMemberPatterns.Add("Ns.Type.Member");
+
+        TypePlan typePlan = ForType(context, "Ns.Type");
+
+        Assert.That(typePlan.DecideMember("Member", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.DeniedExplicitly));
+    }
+
+    [Test]
+    public static void DecideMember_ExplicitMemberBeatsDeniedType()
+    {
+        var context = new PublicizerAssemblyContext("Asm");
+        context.DoNotPublicizeMemberPatterns.Add("Ns.Type");
+        context.PublicizeMemberPatterns.Add("Ns.Type.Member");
+
+        TypePlan typePlan = ForType(context, "Ns.Type");
+
+        Assert.That(typePlan.DecideMember("Member", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Explicit));
+        Assert.That(typePlan.DecideMember("Other", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Skip));
+    }
+
+    [Test]
+    public static void DecideMember_ExplicitBypassesTheSweepFilters()
+    {
+        PublicizerAssemblyContext context = SweepAll();
+        context.IncludeCompilerGeneratedMembers = false;
+        context.PublicizeMemberRegexPattern = VisiblePattern();
+        context.PublicizeMemberPatterns.Add("Ns.Type.Hidden");
+
+        TypePlan typePlan = ForType(context, "Ns.Type");
+
+        Assert.That(typePlan.DecideMember("Hidden", isCompilerGenerated: true), Is.EqualTo(PublicizeDecision.Explicit));
+    }
+
+    [Test]
+    public static void DecideMember_SweepAppliesRegexToTheFlatName()
+    {
+        PublicizerAssemblyContext context = SweepAll();
+        context.PublicizeMemberRegexPattern = VisiblePattern();
+
+        TypePlan typePlan = ForType(context, "Ns.Type");
+
+        Assert.That(typePlan.DecideMember("VisibleMember", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.ByAssemblyRule));
+        Assert.That(typePlan.DecideMember("HiddenMember", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Skip));
+    }
+
+    [Test]
+    public static void PublicizedTypeTarget_DoesNotReachItsMembers_ButDeniedTypeTargetDoes()
+    {
+        // The allow/deny asymmetry documented in docs/publicization-semantics.md: naming a type in
+        // Publicize publicizes only the type, while naming it in DoNotPublicize also suppresses
+        // every member inside it.
+        var allow = new PublicizerAssemblyContext("Asm");
+        allow.PublicizeMemberPatterns.Add("Ns.Type");
+        TypePlan allowPlan = ForType(allow, "Ns.Type");
+
+        Assert.That(allowPlan.DecideType(isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Explicit));
+        Assert.That(allowPlan.DecideMember("Member", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Skip));
+
+        PublicizerAssemblyContext deny = SweepAll();
+        deny.DoNotPublicizeMemberPatterns.Add("Ns.Type");
+        TypePlan denyPlan = ForType(deny, "Ns.Type");
+
+        Assert.That(denyPlan.DecideType(isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.DeniedExplicitly));
+        Assert.That(denyPlan.DecideMember("Member", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Skip));
+    }
+
+    [Test]
+    public static void DecideMember_ConstructorTarget_SurvivesTheDoubledDot()
+    {
+        // "Ns.Type..ctor" splits into ("Ns.Type", ".ctor"), which a split at the last dot would miss.
+        var context = new PublicizerAssemblyContext("Asm");
+        context.PublicizeMemberPatterns.Add("Ns.Type..ctor");
+
+        TypePlan typePlan = ForType(context, "Ns.Type");
+
+        Assert.That(typePlan.DecideMember(".ctor", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Explicit));
+    }
+
+    [Test]
+    public static void DecideMember_AmbiguousTarget_MatchesEitherReading()
+    {
+        // "A.B.C" may name type A.B.C, or member C of type A.B. The syntax cannot say which, so
+        // both readings must match — exactly as the flat string comparison did.
+        var context = new PublicizerAssemblyContext("Asm");
+        context.PublicizeMemberPatterns.Add("A.B.C");
+
+        Assert.That(ForType(context, "A.B").DecideMember("C", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Explicit));
+        Assert.That(ForType(context, "A.B.C").DecideType(isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Explicit));
+        Assert.That(ForType(context, "A").DecideMember("B.C", isCompilerGenerated: false), Is.EqualTo(PublicizeDecision.Explicit));
+    }
+
+    [Test]
+    public static void TryDecideAllMembers_PlainSweep_IsUniform()
+    {
+        TypePlan typePlan = ForType(SweepAll(), "Ns.Type");
+
+        Assert.That(typePlan.TryDecideAllMembers(out PublicizeDecision decision), Is.True);
+        Assert.That(decision, Is.EqualTo(PublicizeDecision.ByAssemblyRule));
+    }
+
+    [Test]
+    public static void TryDecideAllMembers_DeniedType_IsUniformlySkipped()
+    {
+        PublicizerAssemblyContext context = SweepAll();
+        context.DoNotPublicizeMemberPatterns.Add("Ns.Type");
+
+        TypePlan typePlan = ForType(context, "Ns.Type");
+
+        Assert.That(typePlan.TryDecideAllMembers(out PublicizeDecision decision), Is.True);
+        Assert.That(decision, Is.EqualTo(PublicizeDecision.Skip));
+    }
+
+    [Test]
+    public static void TryDecideAllMembers_PerMemberFilters_AreNotUniform()
+    {
+        PublicizerAssemblyContext withRegex = SweepAll();
+        withRegex.PublicizeMemberRegexPattern = VisiblePattern();
+        Assert.That(ForType(withRegex, "Ns.Type").TryDecideAllMembers(out _), Is.False);
+
+        PublicizerAssemblyContext withoutCompilerGenerated = SweepAll();
+        withoutCompilerGenerated.IncludeCompilerGeneratedMembers = false;
+        Assert.That(ForType(withoutCompilerGenerated, "Ns.Type").TryDecideAllMembers(out _), Is.False);
+
+        PublicizerAssemblyContext withNamedTarget = SweepAll();
+        withNamedTarget.DoNotPublicizeMemberPatterns.Add("Ns.Type.Member");
+        Assert.That(ForType(withNamedTarget, "Ns.Type").TryDecideAllMembers(out _), Is.False);
+    }
+
+    [Test]
+    public static void NeedsCompilerGeneratedCheck_OnlyWhenTheSweepFiltersOnIt()
+    {
+        PublicizerAssemblyContext filtering = SweepAll();
+        filtering.IncludeCompilerGeneratedMembers = false;
+        Assert.That(AssemblyPlan.Compile(filtering).NeedsCompilerGeneratedCheck, Is.True);
+
+        Assert.That(AssemblyPlan.Compile(SweepAll()).NeedsCompilerGeneratedCheck, Is.False);
+
+        var namedOnly = new PublicizerAssemblyContext("Asm") { IncludeCompilerGeneratedMembers = false };
+        namedOnly.PublicizeMemberPatterns.Add("Ns.Type.Member");
+        Assert.That(AssemblyPlan.Compile(namedOnly).NeedsCompilerGeneratedCheck, Is.False);
+    }
+}

--- a/src/Publicizer/AssemblyPlan.cs
+++ b/src/Publicizer/AssemblyPlan.cs
@@ -1,0 +1,120 @@
+using System.Text.RegularExpressions;
+
+namespace Publicizer;
+
+/// <summary>
+/// A <see cref="PublicizerAssemblyContext"/> compiled into the structures the member walk needs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The context stores targets as flat dotted strings that are compared against
+/// <c>{TypeReflectionFullName}.{MemberName}</c>. Rebuilding that concatenation for every member of
+/// every type is the dominant cost of matching, so instead each target is decomposed once, up front,
+/// into the (type name, member name) pairs it could denote. The member walk then does a single
+/// dictionary lookup per type and plain lookups per member, never concatenating.
+/// </para>
+/// <para>
+/// A target is ambiguous by construction: <c>A.B.C</c> may name a type, or member <c>C</c> of type
+/// <c>A.B</c>, and the syntax gives no way to tell. Rather than guess, a target is indexed under
+/// <em>every</em> split point, plus as a type name in its own right. That is exactly equivalent to
+/// the string comparison it replaces — including the doubled dot of <c>Fixture.Shapes..ctor</c>,
+/// which a naive split at the last dot would get wrong. Targets are few and user-authored, so the
+/// extra entries cost nothing.
+/// </para>
+/// </remarks>
+internal sealed class AssemblyPlan
+{
+    private readonly Dictionary<string, HashSet<string>> allowedMembersByType;
+    private readonly Dictionary<string, HashSet<string>> deniedMembersByType;
+    private readonly HashSet<string> allowedTypeNames;
+    private readonly HashSet<string> deniedTypeNames;
+
+    private AssemblyPlan(
+        Dictionary<string, HashSet<string>> allowedMembersByType,
+        Dictionary<string, HashSet<string>> deniedMembersByType,
+        HashSet<string> allowedTypeNames,
+        HashSet<string> deniedTypeNames,
+        PublicizerAssemblyContext context)
+    {
+        this.allowedMembersByType = allowedMembersByType;
+        this.deniedMembersByType = deniedMembersByType;
+        this.allowedTypeNames = allowedTypeNames;
+        this.deniedTypeNames = deniedTypeNames;
+
+        PublicizeAll = context.ExplicitlyPublicizeAssembly;
+        DenyAll = context.ExplicitlyDoNotPublicizeAssembly;
+        IncludeVirtualMembers = context.IncludeVirtualMembers;
+        MemberRegex = context.PublicizeMemberRegexPattern;
+        NeedsCompilerGeneratedCheck = context.ExplicitlyPublicizeAssembly && !context.IncludeCompilerGeneratedMembers;
+    }
+
+    internal bool PublicizeAll { get; }
+    internal bool DenyAll { get; }
+    internal bool IncludeVirtualMembers { get; }
+    internal Regex? MemberRegex { get; }
+
+    /// <summary>
+    /// Whether the compiler-generated attribute scan can affect any decision. Hoisted here so the
+    /// walk runs the scan only when it matters, rather than once per member.
+    /// </summary>
+    internal bool NeedsCompilerGeneratedCheck { get; }
+
+    internal static AssemblyPlan Compile(PublicizerAssemblyContext context)
+    {
+        var allowedMembersByType = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        var deniedMembersByType = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+
+        foreach (string target in context.PublicizeMemberPatterns)
+        {
+            IndexMemberSplits(target, allowedMembersByType);
+        }
+
+        foreach (string target in context.DoNotPublicizeMemberPatterns)
+        {
+            IndexMemberSplits(target, deniedMembersByType);
+        }
+
+        var allowedTypeNames = new HashSet<string>(context.PublicizeMemberPatterns, StringComparer.Ordinal);
+        var deniedTypeNames = new HashSet<string>(context.DoNotPublicizeMemberPatterns, StringComparer.Ordinal);
+
+        return new AssemblyPlan(allowedMembersByType, deniedMembersByType, allowedTypeNames, deniedTypeNames, context);
+    }
+
+    private static void IndexMemberSplits(string target, Dictionary<string, HashSet<string>> index)
+    {
+        for (int i = target.IndexOf('.'); i >= 0; i = target.IndexOf('.', i + 1))
+        {
+            string typeName = target.Substring(0, i);
+            string memberName = target.Substring(i + 1);
+
+            if (!index.TryGetValue(typeName, out HashSet<string>? memberNames))
+            {
+                memberNames = new HashSet<string>(StringComparer.Ordinal);
+                index.Add(typeName, memberNames);
+            }
+
+            memberNames.Add(memberName);
+        }
+    }
+
+    /// <summary>
+    /// Returns the rules that can apply inside <paramref name="typeReflectionFullName"/>, or
+    /// <see langword="null"/> when nothing in the type is reachable by any rule and the whole type
+    /// can be skipped without inspecting a single member.
+    /// </summary>
+    internal TypePlan? ForType(string typeReflectionFullName)
+    {
+        _ = allowedMembersByType.TryGetValue(typeReflectionFullName, out HashSet<string>? allowedMembers);
+        _ = deniedMembersByType.TryGetValue(typeReflectionFullName, out HashSet<string>? deniedMembers);
+        bool allowedAsType = allowedTypeNames.Contains(typeReflectionFullName);
+        bool deniedAsType = deniedTypeNames.Contains(typeReflectionFullName);
+
+        bool hasNamedTarget = allowedMembers is not null || deniedMembers is not null || allowedAsType || deniedAsType;
+        if (!hasNamedTarget && !PublicizeAll)
+        {
+            return null;
+        }
+
+        return new TypePlan(this, typeReflectionFullName, allowedMembers, deniedMembers, allowedAsType, deniedAsType);
+    }
+}

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -225,6 +225,8 @@ public sealed class PublicizeAssemblies : Task
 
     internal static bool PublicizeAssembly(ModuleDef module, PublicizerAssemblyContext assemblyContext, ITaskLogger logger)
     {
+        var assemblyPlan = AssemblyPlan.Compile(assemblyContext);
+
         bool publicizedAnyMemberInAssembly = false;
         var doNotPublicizePropertyMethods = new HashSet<MethodDef>();
 
@@ -233,204 +235,150 @@ public sealed class PublicizeAssemblies : Task
         int publicizedMethodsCount = 0;
         int publicizedFieldsCount = 0;
 
-        // TYPES
         foreach (TypeDef? typeDef in module.GetTypes())
         {
-            doNotPublicizePropertyMethods.Clear();
-
-            bool publicizedAnyMemberInType = false;
             string typeName = typeDef.ReflectionFullName;
-
-            bool explicitlyDoNotPublicizeType = assemblyContext.DoNotPublicizeMemberPatterns.Contains(typeName);
-
-            // PROPERTIES
-            foreach (PropertyDef? propertyDef in typeDef.Properties)
+            if (assemblyPlan.ForType(typeName) is not TypePlan typePlan)
             {
-                string propertyName = $"{typeName}.{propertyDef.Name}";
+                // No rule can reach anything in this type; skip it without touching a member.
+                continue;
+            }
 
-                bool explicitlyDoNotPublicizeProperty = assemblyContext.DoNotPublicizeMemberPatterns.Contains(propertyName);
-                if (explicitlyDoNotPublicizeProperty)
+            doNotPublicizePropertyMethods.Clear();
+            bool publicizedAnyMemberInType = false;
+
+            bool needsCompilerGeneratedCheck = typePlan.NeedsCompilerGeneratedCheck;
+            bool allMembersDecided = typePlan.TryDecideAllMembers(out PublicizeDecision uniformDecision);
+            bool anyMemberCanBePublicized = !allMembersDecided || uniformDecision != PublicizeDecision.Skip;
+
+            // Properties are walked before methods so that a denied property can suppress its own
+            // accessors when the method loop reaches them.
+            if (anyMemberCanBePublicized)
+            {
+                foreach (PropertyDef? propertyDef in typeDef.Properties)
                 {
-                    if (propertyDef.GetMethod is MethodDef getter)
+                    PublicizeDecision decision = allMembersDecided
+                        ? uniformDecision
+                        : typePlan.DecideMember(propertyDef.Name, needsCompilerGeneratedCheck && IsCompilerGenerated(propertyDef));
+
+                    switch (decision)
                     {
-                        doNotPublicizePropertyMethods.Add(getter);
+                        case PublicizeDecision.DeniedExplicitly:
+                            if (propertyDef.GetMethod is MethodDef getter)
+                            {
+                                doNotPublicizePropertyMethods.Add(getter);
+                            }
+                            if (propertyDef.SetMethod is MethodDef setter)
+                            {
+                                doNotPublicizePropertyMethods.Add(setter);
+                            }
+                            logger.Verbose($"Explicitly ignoring property: {typePlan.FullNameOf(propertyDef.Name)}");
+                            break;
+
+                        case PublicizeDecision.Explicit:
+                            // Naming a member is an unambiguous opt-in that outranks IncludeVirtualMembers.
+                            if (AssemblyEditor.PublicizeProperty(propertyDef, includeVirtual: true))
+                            {
+                                publicizedAnyMemberInType = true;
+                                publicizedAnyMemberInAssembly = true;
+                                publicizedPropertiesCount++;
+                                logger.Verbose($"Explicitly publicizing property: {typePlan.FullNameOf(propertyDef.Name)}");
+                            }
+                            break;
+
+                        case PublicizeDecision.ByAssemblyRule:
+                            if (AssemblyEditor.PublicizeProperty(propertyDef, typePlan.IncludeVirtualMembers))
+                            {
+                                publicizedAnyMemberInType = true;
+                                publicizedAnyMemberInAssembly = true;
+                                publicizedPropertiesCount++;
+                            }
+                            break;
+
+                        case PublicizeDecision.Skip:
+                        default:
+                            break;
                     }
-                    if (propertyDef.SetMethod is MethodDef setter)
-                    {
-                        doNotPublicizePropertyMethods.Add(setter);
-                    }
-                    logger.Verbose($"Explicitly ignoring property: {propertyName}");
-                    continue;
                 }
 
-                bool explicitlyPublicizeProperty = assemblyContext.PublicizeMemberPatterns.Contains(propertyName);
-                if (explicitlyPublicizeProperty)
+                foreach (MethodDef? methodDef in typeDef.Methods)
                 {
-                    if (AssemblyEditor.PublicizeProperty(propertyDef))
-                    {
-                        publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedPropertiesCount++;
-                        logger.Verbose($"Explicitly publicizing property: {propertyName}");
-                    }
-                    continue;
-                }
-
-                if (explicitlyDoNotPublicizeType)
-                {
-                    continue;
-                }
-
-                if (assemblyContext.ExplicitlyDoNotPublicizeAssembly)
-                {
-                    continue;
-                }
-
-                if (assemblyContext.ExplicitlyPublicizeAssembly)
-                {
-                    bool isCompilerGeneratedProperty = IsCompilerGenerated(propertyDef);
-                    if (isCompilerGeneratedProperty && !assemblyContext.IncludeCompilerGeneratedMembers)
+                    if (doNotPublicizePropertyMethods.Contains(methodDef))
                     {
                         continue;
                     }
 
-                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(propertyName) ?? true;
-                    if (!isRegexPatternMatch)
-                    {
-                        continue;
-                    }
+                    PublicizeDecision decision = allMembersDecided
+                        ? uniformDecision
+                        : typePlan.DecideMember(methodDef.Name, needsCompilerGeneratedCheck && IsCompilerGenerated(methodDef));
 
-                    if (AssemblyEditor.PublicizeProperty(propertyDef, assemblyContext.IncludeVirtualMembers))
+                    switch (decision)
                     {
-                        publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedPropertiesCount++;
+                        case PublicizeDecision.DeniedExplicitly:
+                            logger.Verbose($"Explicitly ignoring method: {typePlan.FullNameOf(methodDef.Name)}");
+                            break;
+
+                        case PublicizeDecision.Explicit:
+                            if (AssemblyEditor.PublicizeMethod(methodDef, includeVirtual: true))
+                            {
+                                publicizedAnyMemberInType = true;
+                                publicizedAnyMemberInAssembly = true;
+                                publicizedMethodsCount++;
+                                logger.Verbose($"Explicitly publicizing method: {typePlan.FullNameOf(methodDef.Name)}");
+                            }
+                            break;
+
+                        case PublicizeDecision.ByAssemblyRule:
+                            if (AssemblyEditor.PublicizeMethod(methodDef, typePlan.IncludeVirtualMembers))
+                            {
+                                publicizedAnyMemberInType = true;
+                                publicizedAnyMemberInAssembly = true;
+                                publicizedMethodsCount++;
+                            }
+                            break;
+
+                        case PublicizeDecision.Skip:
+                        default:
+                            break;
+                    }
+                }
+
+                foreach (FieldDef? fieldDef in typeDef.Fields)
+                {
+                    PublicizeDecision decision = allMembersDecided
+                        ? uniformDecision
+                        : typePlan.DecideMember(fieldDef.Name, needsCompilerGeneratedCheck && IsCompilerGenerated(fieldDef));
+
+                    switch (decision)
+                    {
+                        case PublicizeDecision.DeniedExplicitly:
+                            logger.Verbose($"Explicitly ignoring field: {typePlan.FullNameOf(fieldDef.Name)}");
+                            break;
+
+                        case PublicizeDecision.Explicit:
+                        case PublicizeDecision.ByAssemblyRule:
+                            // IncludeVirtualMembers has no meaning for fields.
+                            if (AssemblyEditor.PublicizeField(fieldDef))
+                            {
+                                publicizedAnyMemberInType = true;
+                                publicizedAnyMemberInAssembly = true;
+                                publicizedFieldsCount++;
+                                if (decision == PublicizeDecision.Explicit)
+                                {
+                                    logger.Verbose($"Explicitly publicizing field: {typePlan.FullNameOf(fieldDef.Name)}");
+                                }
+                            }
+                            break;
+
+                        case PublicizeDecision.Skip:
+                        default:
+                            break;
                     }
                 }
             }
 
-            // METHODS
-            foreach (MethodDef? methodDef in typeDef.Methods)
-            {
-                string methodName = $"{typeName}.{methodDef.Name}";
-
-                bool isMethodOfNonPublicizedProperty = doNotPublicizePropertyMethods.Contains(methodDef);
-                if (isMethodOfNonPublicizedProperty)
-                {
-                    continue;
-                }
-
-                bool explicitlyDoNotPublicizeMethod = assemblyContext.DoNotPublicizeMemberPatterns.Contains(methodName);
-                if (explicitlyDoNotPublicizeMethod)
-                {
-                    logger.Verbose($"Explicitly ignoring method: {methodName}");
-                    continue;
-                }
-
-                bool explicitlyPublicizeMethod = assemblyContext.PublicizeMemberPatterns.Contains(methodName);
-                if (explicitlyPublicizeMethod)
-                {
-                    if (AssemblyEditor.PublicizeMethod(methodDef))
-                    {
-                        publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedMethodsCount++;
-                        logger.Verbose($"Explicitly publicizing method: {methodName}");
-                    }
-                    continue;
-                }
-
-                if (explicitlyDoNotPublicizeType)
-                {
-                    continue;
-                }
-
-                if (assemblyContext.ExplicitlyDoNotPublicizeAssembly)
-                {
-                    continue;
-                }
-
-                if (assemblyContext.ExplicitlyPublicizeAssembly)
-                {
-                    bool isCompilerGeneratedMethod = IsCompilerGenerated(methodDef);
-                    if (isCompilerGeneratedMethod && !assemblyContext.IncludeCompilerGeneratedMembers)
-                    {
-                        continue;
-                    }
-
-                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(methodName) ?? true;
-                    if (!isRegexPatternMatch)
-                    {
-                        continue;
-                    }
-
-                    if (AssemblyEditor.PublicizeMethod(methodDef, assemblyContext.IncludeVirtualMembers))
-                    {
-                        publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedMethodsCount++;
-                    }
-                }
-            }
-
-            // FIELDS
-            foreach (FieldDef? fieldDef in typeDef.Fields)
-            {
-                string fieldName = $"{typeName}.{fieldDef.Name}";
-
-                bool explicitlyDoNotPublicizeField = assemblyContext.DoNotPublicizeMemberPatterns.Contains(fieldName);
-                if (explicitlyDoNotPublicizeField)
-                {
-                    logger.Verbose($"Explicitly ignoring field: {fieldName}");
-                    continue;
-                }
-
-                bool explicitlyPublicizeField = assemblyContext.PublicizeMemberPatterns.Contains(fieldName);
-                if (explicitlyPublicizeField)
-                {
-                    if (AssemblyEditor.PublicizeField(fieldDef))
-                    {
-                        publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedFieldsCount++;
-                        logger.Verbose($"Explicitly publicizing field: {fieldName}");
-                    }
-                    continue;
-                }
-
-                if (explicitlyDoNotPublicizeType)
-                {
-                    continue;
-                }
-
-                if (assemblyContext.ExplicitlyDoNotPublicizeAssembly)
-                {
-                    continue;
-                }
-
-                if (assemblyContext.ExplicitlyPublicizeAssembly)
-                {
-                    bool isCompilerGeneratedField = IsCompilerGenerated(fieldDef);
-                    if (isCompilerGeneratedField && !assemblyContext.IncludeCompilerGeneratedMembers)
-                    {
-                        continue;
-                    }
-
-                    bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(fieldName) ?? true;
-                    if (!isRegexPatternMatch)
-                    {
-                        continue;
-                    }
-
-                    if (AssemblyEditor.PublicizeField(fieldDef))
-                    {
-                        publicizedAnyMemberInType = true;
-                        publicizedAnyMemberInAssembly = true;
-                        publicizedFieldsCount++;
-                    }
-                }
-            }
-
+            // A type with any publicized member is publicized regardless of its own rules — a
+            // publicized member is useless in an inaccessible type.
             if (publicizedAnyMemberInType)
             {
                 if (AssemblyEditor.PublicizeType(typeDef))
@@ -441,48 +389,29 @@ public sealed class PublicizeAssemblies : Task
                 continue;
             }
 
-            if (explicitlyDoNotPublicizeType)
+            PublicizeDecision typeDecision = typePlan.DecideType(needsCompilerGeneratedCheck && IsCompilerGenerated(typeDef));
+            switch (typeDecision)
             {
-                logger.Verbose($"Explicitly ignoring type: {typeName}");
-                continue;
-            }
+                case PublicizeDecision.DeniedExplicitly:
+                    logger.Verbose($"Explicitly ignoring type: {typeName}");
+                    break;
 
-            bool explicitlyPublicizeType = assemblyContext.PublicizeMemberPatterns.Contains(typeName);
-            if (explicitlyPublicizeType)
-            {
-                if (AssemblyEditor.PublicizeType(typeDef))
-                {
-                    publicizedAnyMemberInAssembly = true;
-                    publicizedTypesCount++;
-                    logger.Verbose($"Explicitly publicizing type: {typeName}");
-                }
-                continue;
-            }
+                case PublicizeDecision.Explicit:
+                case PublicizeDecision.ByAssemblyRule:
+                    if (AssemblyEditor.PublicizeType(typeDef))
+                    {
+                        publicizedAnyMemberInAssembly = true;
+                        publicizedTypesCount++;
+                        if (typeDecision == PublicizeDecision.Explicit)
+                        {
+                            logger.Verbose($"Explicitly publicizing type: {typeName}");
+                        }
+                    }
+                    break;
 
-            if (assemblyContext.ExplicitlyDoNotPublicizeAssembly)
-            {
-                continue;
-            }
-
-            if (assemblyContext.ExplicitlyPublicizeAssembly)
-            {
-                bool isCompilerGeneratedType = IsCompilerGenerated(typeDef);
-                if (isCompilerGeneratedType && !assemblyContext.IncludeCompilerGeneratedMembers)
-                {
-                    continue;
-                }
-
-                bool isRegexPatternMatch = assemblyContext.PublicizeMemberRegexPattern?.IsMatch(typeName) ?? true;
-                if (!isRegexPatternMatch)
-                {
-                    continue;
-                }
-
-                if (AssemblyEditor.PublicizeType(typeDef))
-                {
-                    publicizedAnyMemberInAssembly = true;
-                    publicizedTypesCount++;
-                }
+                case PublicizeDecision.Skip:
+                default:
+                    break;
             }
         }
 

--- a/src/Publicizer/PublicizeDecision.cs
+++ b/src/Publicizer/PublicizeDecision.cs
@@ -1,0 +1,22 @@
+namespace Publicizer;
+
+/// <summary>
+/// The outcome of evaluating one type or member against the publicization rules.
+/// </summary>
+internal enum PublicizeDecision
+{
+    /// <summary>No rule applies; leave accessibility untouched.</summary>
+    Skip,
+
+    /// <summary>A DoNotPublicize target names this exactly. Distinct from <see cref="Skip"/>
+    /// because the walker suppresses the accessors of a denied property and logs the denial.</summary>
+    DeniedExplicitly,
+
+    /// <summary>A Publicize target names this exactly. Bypasses the compiler-generated,
+    /// regex and virtual filters — see the escape hatch in docs/publicization-semantics.md.</summary>
+    Explicit,
+
+    /// <summary>Matched only by the assembly-wide sweep, so the filters have already been applied
+    /// and <c>IncludeVirtualMembers</c> still governs the edit.</summary>
+    ByAssemblyRule,
+}

--- a/src/Publicizer/TypePlan.cs
+++ b/src/Publicizer/TypePlan.cs
@@ -1,0 +1,133 @@
+namespace Publicizer;
+
+/// <summary>
+/// The publicization rules that can apply inside one type, with all per-type work already hoisted
+/// out of the member loops. Holds the single copy of the decision ladder that
+/// <see cref="PublicizeAssemblies.PublicizeAssembly"/> used to repeat once per member kind.
+/// </summary>
+internal sealed class TypePlan
+{
+    private readonly AssemblyPlan assemblyPlan;
+    private readonly string typeReflectionFullName;
+    private readonly HashSet<string>? allowedMembers;
+    private readonly HashSet<string>? deniedMembers;
+    private readonly bool allowedAsType;
+    private readonly bool deniedAsType;
+
+    internal TypePlan(
+        AssemblyPlan assemblyPlan,
+        string typeReflectionFullName,
+        HashSet<string>? allowedMembers,
+        HashSet<string>? deniedMembers,
+        bool allowedAsType,
+        bool deniedAsType)
+    {
+        this.assemblyPlan = assemblyPlan;
+        this.typeReflectionFullName = typeReflectionFullName;
+        this.allowedMembers = allowedMembers;
+        this.deniedMembers = deniedMembers;
+        this.allowedAsType = allowedAsType;
+        this.deniedAsType = deniedAsType;
+    }
+
+    internal bool NeedsCompilerGeneratedCheck => assemblyPlan.NeedsCompilerGeneratedCheck;
+
+    internal bool IncludeVirtualMembers => assemblyPlan.IncludeVirtualMembers;
+
+    /// <summary>
+    /// The name a diagnostic or the <c>MemberPattern</c> regex needs. Built on demand only, since
+    /// deciding a member no longer requires it.
+    /// </summary>
+    internal string FullNameOf(string memberName) => typeReflectionFullName + "." + memberName;
+
+    /// <summary>
+    /// Answers for every member at once when no rule depends on the member, letting the walk skip
+    /// name lookups entirely. This is the common whole-assembly case.
+    /// </summary>
+    internal bool TryDecideAllMembers(out PublicizeDecision decision)
+    {
+        decision = PublicizeDecision.Skip;
+
+        if (allowedMembers is not null || deniedMembers is not null)
+        {
+            return false;
+        }
+
+        if (deniedAsType || assemblyPlan.DenyAll || !assemblyPlan.PublicizeAll)
+        {
+            return true;
+        }
+
+        if (assemblyPlan.MemberRegex is not null || assemblyPlan.NeedsCompilerGeneratedCheck)
+        {
+            return false;
+        }
+
+        decision = PublicizeDecision.ByAssemblyRule;
+        return true;
+    }
+
+    internal PublicizeDecision DecideMember(string memberName, bool isCompilerGenerated)
+    {
+        if (deniedMembers is not null && deniedMembers.Contains(memberName))
+        {
+            return PublicizeDecision.DeniedExplicitly;
+        }
+
+        if (allowedMembers is not null && allowedMembers.Contains(memberName))
+        {
+            return PublicizeDecision.Explicit;
+        }
+
+        if (deniedAsType)
+        {
+            return PublicizeDecision.Skip;
+        }
+
+        return DecideBySweep(memberName, isCompilerGenerated);
+    }
+
+    internal PublicizeDecision DecideType(bool isCompilerGenerated)
+    {
+        if (deniedAsType)
+        {
+            return PublicizeDecision.DeniedExplicitly;
+        }
+
+        if (allowedAsType)
+        {
+            return PublicizeDecision.Explicit;
+        }
+
+        return DecideBySweep(memberName: null, isCompilerGenerated);
+    }
+
+    /// <summary>
+    /// The assembly-wide sweep and its filters. <paramref name="memberName"/> is
+    /// <see langword="null"/> when deciding the type itself.
+    /// </summary>
+    private PublicizeDecision DecideBySweep(string? memberName, bool isCompilerGenerated)
+    {
+        if (assemblyPlan.DenyAll || !assemblyPlan.PublicizeAll)
+        {
+            return PublicizeDecision.Skip;
+        }
+
+        if (isCompilerGenerated && assemblyPlan.NeedsCompilerGeneratedCheck)
+        {
+            return PublicizeDecision.Skip;
+        }
+
+        if (assemblyPlan.MemberRegex is not null)
+        {
+            // The only place the flat name is still needed, and only when a regex was configured.
+            string matchedName = memberName is null ? typeReflectionFullName : FullNameOf(memberName);
+            if (!assemblyPlan.MemberRegex.IsMatch(matchedName))
+            {
+                return PublicizeDecision.Skip;
+            }
+        }
+
+        return PublicizeDecision.ByAssemblyRule;
+    }
+}


### PR DESCRIPTION
Pulls the publicization decision out of `PublicizeAssembly`'s four repeated ladders into a single compiled matcher, as the first slice of the structured-matcher rewrite. Internal only — no change to the `Publicize` item syntax or to publicization behavior.

`AssemblyPlan` compiles a `PublicizerAssemblyContext` once. Each target is decomposed into the (type, member) pairs it could denote, so deciding a member is a per-type set lookup rather than rebuilding `{Type}.{Member}` for every member of every type. Types no rule can reach are skipped without inspecting a member, and a plain whole-assembly sweep is answered uniformly without building any name at all.

- Targets are ambiguous by construction (`A.B.C` may name a type, or member `C` of type `A.B`), so each is indexed under every split point instead of guessed at. This is what keeps `Type..ctor` matching, which a split at the last dot would break.
- `PublicizeDecision` separates an explicit hit from an assembly-rule hit. The distinction was previously carried by a default parameter value — explicitly named members bypass `IncludeVirtualMembers`, the escape hatch the README's "publicize specific ignored members" pattern depends on.

Behavior-preserving. Beyond the untouched characterization snapshots, the old and new engines were run head-to-head over 14 target scenarios against dnlib, Microsoft.Build.Utilities.Core and System.Private.CoreLib; the resulting accessibility is byte-identical in every case.

The board item "Extract the publicization decision behind a matcher seam" is superseded by this — its proposed interface keyed on a flattened reflection name, which cannot express the overload and accessor targeting the new syntax needs.