### PR TITLE
Fix DoNotPublicize on types with nested types

### DIFF
--- a/docs/publicization-semantics.md
+++ b/docs/publicization-semantics.md
@@ -88,7 +88,7 @@ Consequences worth naming explicitly:
 - **Field** — access bits cleared, `Public` set. Unconditional; `IncludeVirtualMembers` has no meaning for fields (`AssemblyEditor.cs:65`).
 - **Method** — access bits cleared, `Public` set, unless `includeVirtual` is false and the method is virtual, in which case nothing happens (`AssemblyEditor.cs:53`).
 - **Property** — the property itself has no accessibility in IL; publicizing one means publicizing its getter and setter, each subject to the virtual check (`AssemblyEditor.cs:36`).
-- **Type** — visibility bits cleared, then `Public` for a top-level type or `NestedPublic` for a nested one. The engine then **walks up the declaring-type chain** and does the same to every enclosing type, because a nested type is unreachable unless all its enclosers are too (`AssemblyEditor.cs:16`). Pinned by `PublicizeType_ByName_PublicizesTypeAndWalksUp` and `NestedMember_AlsoPublicizesEnclosingType`.
+- **Type** — visibility bits cleared, then `Public` for a top-level type or `NestedPublic` for a nested one. The engine then **walks up the declaring-type chain** and does the same to every enclosing type, because a nested type is unreachable unless all its enclosers are too (`PublicizeAssemblies.PublicizeTypeAndEnclosers`). Pinned by `PublicizeType_ByName_PublicizesTypeAndWalksUp` and `NestedMember_AlsoPublicizesEnclosingType`. The walk-up stops at an enclosing type named in `DoNotPublicize`: it is the engine's own inference, so it yields to what the user asked for by name, leaving the nested type public but unreachable (`DoNotPublicizeType_SurvivesTheWalkUpFromItsNestedTypes`).
 
 Each of these returns whether it actually changed anything, so publicizing an already-public member reports no modification.
 
@@ -131,7 +131,7 @@ For completeness, behavior that surrounds publicization but isn't part of the ma
 
 ## Publicization does not close over dependencies
 
-Publicization changes the accessibility of the members it matches by name, and nothing else. It never inspects a member's signature. The only transitive rule in the engine is the declaring-type walk-up for nested types (`AssemblyEditor.cs:16`).
+Publicization changes the accessibility of the members it matches by name, and nothing else. It never inspects a member's signature. The only transitive rule in the engine is the declaring-type walk-up for nested types (`PublicizeAssemblies.PublicizeTypeAndEnclosers`).
 
 So a member can become public and still be unusable:
 
@@ -167,6 +167,6 @@ Collected here as rewrite input. None of these are bugs the current tests fail o
 7. A no-match target is silent.
 8. Assembly name matching is case-sensitive, which is surprising on Windows.
 9. `DoNotPublicize` on a type does not prevent that type from being made public via an explicitly targeted member.
-10. `DoNotPublicize` on a type does not extend to its nested types; each nested type has its own reflection name and must be named separately (`DoNotPublicizeType_DoesNotExtendToNestedTypes`).
+10. `DoNotPublicize` on a type does not extend to its nested types; each nested type has its own reflection name and must be named separately (`DoNotPublicizeType_DoesNotExtendToNestedTypes`). Publicizing those nested types no longer drags the excluded encloser public via the walk-up (`DoNotPublicizeType_SurvivesTheWalkUpFromItsNestedTypes`).
 11. Publicization does not close over signature types, so targeted publicization can produce public-but-unusable members.
 12. Per-item options only exist on the assembly form, so "all members of this type" is only expressible as a regex.

--- a/src/Publicizer.Tests/AssemblyEditorTests.cs
+++ b/src/Publicizer.Tests/AssemblyEditorTests.cs
@@ -74,7 +74,7 @@ internal static class AssemblyEditorTests
     }
 
     [Test]
-    public static void PublicizeType_NestedType_AlsoPublicizesEnclosingType()
+    public static void PublicizeType_NestedType_PublicizesOnlyThatType()
     {
         using ModuleDefMD module = Fixtures.LoadShapesModule();
         TypeDef inner = module.Find("Fixture.Shapes+Inner", isReflectionName: true);
@@ -83,7 +83,8 @@ internal static class AssemblyEditorTests
 
         Assert.That(modified, Is.True);
         Assert.That(inner.IsNestedPublic, Is.True);
-        Assert.That(ShapesType(module).IsPublic, Is.True);
+        // Walking up to the enclosing types is the engine's job, not the editor's
+        // (PublicizeAssemblies.PublicizeTypeAndEnclosers).
     }
 
     [Test]

--- a/src/Publicizer.Tests/WalkUpDenialTests.cs
+++ b/src/Publicizer.Tests/WalkUpDenialTests.cs
@@ -1,0 +1,84 @@
+using dnlib.DotNet;
+using NUnit.Framework;
+
+namespace Publicizer.Tests;
+
+/// <summary>
+/// The declaring-type walk-up is the engine's only transitive rule: publicizing a nested type also
+/// publicizes every type enclosing it, because a nested type is unreachable otherwise. That
+/// inference must not undo an explicit <c>DoNotPublicize</c> on an encloser.
+/// Uses its own fixture because the shared one has no internal type with a nested type — the
+/// enclosers in Shapes are already public, so they cannot show the difference.
+/// </summary>
+internal static class WalkUpDenialTests
+{
+    private const string DenialSource =
+        """
+        namespace Fixture
+        {
+            internal class Outer
+            {
+                private int OuterPrivateField;
+
+                private class Nested
+                {
+                    private int NestedPrivateField;
+                }
+            }
+        }
+        """;
+
+    private static readonly byte[] denialAssembly = Compiler.Compile(DenialSource, "Denial");
+
+    private static ModuleDefMD LoadDenialModule() => ModuleDefMD.Load(denialAssembly);
+
+    private static TypeDef Type(ModuleDef module, string reflectionName) => module.Find(reflectionName, isReflectionName: true);
+
+    private static void Publicize(ModuleDef module, PublicizerAssemblyContext context) =>
+        PublicizeAssemblies.PublicizeAssembly(module, context, NullTaskLogger.Instance);
+
+    [Test]
+    public static void DoNotPublicizeType_SurvivesTheWalkUpFromItsNestedTypes()
+    {
+        using ModuleDefMD module = LoadDenialModule();
+        var context = new PublicizerAssemblyContext("Denial") { ExplicitlyPublicizeAssembly = true };
+        context.DoNotPublicizeMemberPatterns.Add("Fixture.Outer");
+
+        Publicize(module, context);
+
+        // The exclusion still does not reach the nested type, which has its own reflection name...
+        Assert.That(Type(module, "Fixture.Outer+Nested").IsNestedPublic, Is.True);
+        // ...but publicizing it no longer drags the excluded encloser public along with it.
+        Assert.That(Type(module, "Fixture.Outer").IsNotPublic, Is.True);
+    }
+
+    [Test]
+    public static void ExplicitMemberPublicize_StillPublicizesTheDeniedTypeItLivesIn()
+    {
+        using ModuleDefMD module = LoadDenialModule();
+        var context = new PublicizerAssemblyContext("Denial");
+        context.DoNotPublicizeMemberPatterns.Add("Fixture.Outer");
+        context.PublicizeMemberPatterns.Add("Fixture.Outer.OuterPrivateField");
+
+        Publicize(module, context);
+
+        // The walk-up only stops at *enclosing* types. Naming a member of an excluded type still
+        // publicizes that type, or the member just publicized would be unreachable.
+        Assert.That(Type(module, "Fixture.Outer").IsPublic, Is.True);
+    }
+
+    [Test]
+    public static void PublicizeNestedTypeByName_StillWalksUpWhenNothingIsExcluded()
+    {
+        using ModuleDefMD module = LoadDenialModule();
+        var context = new PublicizerAssemblyContext("Denial");
+        context.PublicizeMemberPatterns.Add("Fixture.Outer+Nested");
+
+        Publicize(module, context);
+
+        // The walk-up itself is untouched - with no exclusion in play it still makes the
+        // nested type reachable by publicizing its encloser.
+        Assert.That(Type(module, "Fixture.Outer+Nested").IsNestedPublic, Is.True);
+        Assert.That(Type(module, "Fixture.Outer").IsPublic, Is.True);
+    }
+}

--- a/src/Publicizer/AssemblyEditor.cs
+++ b/src/Publicizer/AssemblyEditor.cs
@@ -7,30 +7,18 @@ namespace Publicizer;
 /// </summary>
 internal static class AssemblyEditor
 {
+    /// <summary>
+    /// Publicizes this type alone. Making a nested type actually reachable also takes its
+    /// enclosing types, which is the engine's call to make, not this one's: see
+    /// <c>PublicizeAssemblies.PublicizeTypeAndEnclosers</c>.
+    /// </summary>
     internal static bool PublicizeType(TypeDef type)
     {
-        bool modified = false;
+        TypeAttributes oldAttributes = type.Attributes;
+        type.Attributes &= ~TypeAttributes.VisibilityMask;
+        type.Attributes |= type.IsNested ? TypeAttributes.NestedPublic : TypeAttributes.Public;
 
-        // A nested type is only reachable if every enclosing type is accessible too,
-        // so walk up the declaring-type chain and publicize each one.
-        for (TypeDef? current = type; current is not null; current = current.DeclaringType)
-        {
-            TypeAttributes oldAttributes = current.Attributes;
-            current.Attributes &= ~TypeAttributes.VisibilityMask;
-
-            if (current.IsNested)
-            {
-                current.Attributes |= TypeAttributes.NestedPublic;
-            }
-            else
-            {
-                current.Attributes |= TypeAttributes.Public;
-            }
-
-            modified |= current.Attributes != oldAttributes;
-        }
-
-        return modified;
+        return type.Attributes != oldAttributes;
     }
 
     internal static bool PublicizeProperty(PropertyDef property, bool includeVirtual = true)

--- a/src/Publicizer/AssemblyPlan.cs
+++ b/src/Publicizer/AssemblyPlan.cs
@@ -98,6 +98,13 @@ internal sealed class AssemblyPlan
     }
 
     /// <summary>
+    /// Whether a <c>DoNotPublicize</c> target names this type. Only consulted for the enclosing
+    /// types the walk-up would otherwise publicize; deciding a type the walk reached on its own
+    /// goes through <see cref="ForType"/>.
+    /// </summary>
+    internal bool IsDeniedType(string typeReflectionFullName) => deniedTypeNames.Contains(typeReflectionFullName);
+
+    /// <summary>
     /// Returns the rules that can apply inside <paramref name="typeReflectionFullName"/>, or
     /// <see langword="null"/> when nothing in the type is reachable by any rule and the whole type
     /// can be skipped without inspecting a single member.

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -223,6 +223,30 @@ public sealed class PublicizeAssemblies : Task
         return contexts;
     }
 
+    /// <summary>
+    /// Publicizes a type and every type enclosing it, because a nested type is unreachable unless
+    /// all its enclosers are too. The walk stops at an encloser named in <c>DoNotPublicize</c>:
+    /// reaching it is the engine's own inference, and inference yields to an explicit rule. The
+    /// type itself is never subject to that check - it was already decided by the caller, where an
+    /// explicitly publicized member outranks an excluded type.
+    /// </summary>
+    private static bool PublicizeTypeAndEnclosers(TypeDef type, AssemblyPlan plan)
+    {
+        bool modified = AssemblyEditor.PublicizeType(type);
+
+        for (TypeDef? enclosing = type.DeclaringType; enclosing is not null; enclosing = enclosing.DeclaringType)
+        {
+            if (plan.IsDeniedType(enclosing.ReflectionFullName))
+            {
+                break;
+            }
+
+            modified |= AssemblyEditor.PublicizeType(enclosing);
+        }
+
+        return modified;
+    }
+
     internal static bool PublicizeAssembly(ModuleDef module, PublicizerAssemblyContext assemblyContext, ITaskLogger logger)
     {
         var assemblyPlan = AssemblyPlan.Compile(assemblyContext);
@@ -381,7 +405,7 @@ public sealed class PublicizeAssemblies : Task
             // publicized member is useless in an inaccessible type.
             if (publicizedAnyMemberInType)
             {
-                if (AssemblyEditor.PublicizeType(typeDef))
+                if (PublicizeTypeAndEnclosers(typeDef, assemblyPlan))
                 {
                     publicizedAnyMemberInAssembly = true;
                     publicizedTypesCount++;
@@ -398,7 +422,7 @@ public sealed class PublicizeAssemblies : Task
 
                 case PublicizeDecision.Explicit:
                 case PublicizeDecision.ByAssemblyRule:
-                    if (AssemblyEditor.PublicizeType(typeDef))
+                    if (PublicizeTypeAndEnclosers(typeDef, assemblyPlan))
                     {
                         publicizedAnyMemberInAssembly = true;
                         publicizedTypesCount++;


### PR DESCRIPTION
A `DoNotPublicize` naming a type was silently undone whenever that type had nested types — including compiler-generated ones, so it hits consumers who do not think they have any. The exclusion does not reach nested types, so an assembly-wide sweep publicized them, and the declaring-type walk-up dragged the excluded type public again. Regression since #200, shipped in 2.3.1.

The walk-up is the engine's own inference, so it yields to a type the user excluded by name rather than widening the exclusion to nested types — which would invert documented behavior and break anyone relying on it. Reaching a denied type directly still publicizes it, so an explicitly named member stays usable.

Found by building real consumers against a locally packed Publicizer: [SharpIDE](https://github.com/MattParkerDev/SharpIDE) fails to compile on 2.3.1 and on main with 18 `CS0433`/`CS0121` errors, one per type it excludes, and builds clean with this fix.