### PR TITLE
Fix cache-key collisions between colon-form targets

### DIFF
--- a/src/Publicizer.Tests/HasherTests.cs
+++ b/src/Publicizer.Tests/HasherTests.cs
@@ -99,6 +99,51 @@ internal static partial class HasherTests
     }
 
     [Test]
+    public static void ComputeHash_DistinguishesMemberPatternsThatConcatenateAlike()
+    {
+        // One target "AB" and the two targets "A" and "B" must not collide: the second build would
+        // silently reuse the first build's publicized assembly.
+        var single = new PublicizerAssemblyContext("Fixture");
+        single.PublicizeMemberPatterns.Add("AB");
+
+        var split = new PublicizerAssemblyContext("Fixture");
+        split.PublicizeMemberPatterns.Add("A");
+        split.PublicizeMemberPatterns.Add("B");
+
+        Assert.That(Hash(split), Is.Not.EqualTo(Hash(single)));
+    }
+
+    [Test]
+    public static void ComputeHash_DistinguishesPublicizeFromDoNotPublicizeMemberPattern()
+    {
+        // The same member named by opposite intents. Both leave every Explicitly* flag false, so
+        // the pattern set is the only thing telling them apart: without a per-set tag the
+        // deny-only build finds the allow build's file cached and hands the compiler a publicized
+        // assembly it explicitly asked not to have.
+        var publicize = new PublicizerAssemblyContext("Fixture");
+        publicize.PublicizeMemberPatterns.Add("Fixture.Shapes.PrivateField");
+
+        var doNotPublicize = new PublicizerAssemblyContext("Fixture");
+        doNotPublicize.DoNotPublicizeMemberPatterns.Add("Fixture.Shapes.PrivateField");
+
+        Assert.That(Hash(doNotPublicize), Is.Not.EqualTo(Hash(publicize)));
+    }
+
+    [Test]
+    public static void ComputeHash_MemberPatternOrder_DoesNotChangeHash()
+    {
+        var first = new PublicizerAssemblyContext("Fixture");
+        first.PublicizeMemberPatterns.Add("A");
+        first.PublicizeMemberPatterns.Add("B");
+
+        var second = new PublicizerAssemblyContext("Fixture");
+        second.PublicizeMemberPatterns.Add("B");
+        second.PublicizeMemberPatterns.Add("A");
+
+        Assert.That(Hash(second), Is.EqualTo(Hash(first)));
+    }
+
+    [Test]
     public static void ComputeHash_AddingScope_ChangesHash()
     {
         string baseline = Hash(new PublicizerAssemblyContext("Fixture"));

--- a/src/Publicizer/Hasher.cs
+++ b/src/Publicizer/Hasher.cs
@@ -27,14 +27,13 @@ internal static class Hasher
         sb.Append(assemblyContext.IncludeVirtualMembers);
         sb.Append(assemblyContext.ExplicitlyPublicizeAssembly);
         sb.Append(assemblyContext.ExplicitlyDoNotPublicizeAssembly);
-        foreach (string publicizePattern in assemblyContext.PublicizeMemberPatterns)
-        {
-            sb.Append(publicizePattern);
-        }
-        foreach (string doNotPublicizePattern in assemblyContext.DoNotPublicizeMemberPatterns)
-        {
-            sb.Append(doNotPublicizePattern);
-        }
+        // Delimited and tagged per set, so that "Asm:AB" cannot hash the same as "Asm:A" plus
+        // "Asm:B", and so that a lone Publicize target cannot hash the same as the lone
+        // DoNotPublicize target naming the same member. Sorted because these are HashSets, whose
+        // enumeration order is not contractual: the same targets authored in a different order
+        // must not cost a second cache entry.
+        AppendPatterns(sb, "|publicize|", assemblyContext.PublicizeMemberPatterns);
+        AppendPatterns(sb, "|donotpublicize|", assemblyContext.DoNotPublicizeMemberPatterns);
         if (assemblyContext.PublicizeMemberRegexPattern is not null)
         {
             sb.Append(assemblyContext.PublicizeMemberRegexPattern.ToString());
@@ -56,6 +55,14 @@ internal static class Hasher
         byte[] allBytes = [.. assemblyBytes, .. patternBytes];
 
         return ComputeHash(allBytes);
+    }
+
+    private static void AppendPatterns(StringBuilder sb, string tag, HashSet<string> patterns)
+    {
+        foreach (string pattern in patterns.OrderBy(pattern => pattern, StringComparer.Ordinal))
+        {
+            _ = sb.Append(tag).Append(pattern);
+        }
     }
 
     private static string ComputeHash(byte[] bytes)


### PR DESCRIPTION
`Hasher.ComputeHash` concatenated the two colon-form pattern sets with no delimiter and no per-set tag, so different target sets could produce the same cache key and the second build would silently reuse the first build's publicized assembly.

- `Asm:AB` collided with `Asm:A` plus `Asm:B`.
- A lone `Publicize Include="Asm:A"` collided with a lone `DoNotPublicize Include="Asm:A"` — opposite intent, same cache path, so the deny-only build could be handed a publicized assembly.

Fixed by tagging and delimiting each set, following the serialization the `Scopes` loop already uses. Also sorts each set, since they are `HashSet<string>` whose enumeration order is not contractual — that one only ever cost a redundant cache entry.

Changing the key format invalidates every existing cache entry, so the first build after upgrading re-publicizes each assembly once.

Predates the structured syntax; `Scopes` was already immune.