### PR TITLE
Add diagnostic codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ If the file does not exist it will be created.
 
 The file is overwritten on every execution.
 
+Every error and warning carries a `PUBxxxx` code, so a warning can be suppressed with `NoWarn` or promoted with `WarningsAsErrors` like any compiler warning. See [docs/diagnostics.md](docs/diagnostics.md) for the full table.
+
 ### Clean
 You can instruct Publicizer to clear its cache everytime the project is cleaned:
 ```xml

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -46,6 +46,6 @@ A code is permanent **once it has appeared in a release**: a retired diagnostic 
 </PropertyGroup>
 ```
 
-This is not an SDK feature. `Microsoft.Common.CurrentVersion.targets` folds `NoWarn` into `MSBuildWarningsAsMessages` and `WarningsAsErrors` into `MSBuildWarningsAsErrors`, so it works in non-SDK projects too. Those `MSBuild`-prefixed properties can also be set directly, alongside `MSBuildWarningsNotAsErrors` to exempt a code from a blanket `MSBuildTreatWarningsAsErrors`.
+That works because `Microsoft.Common.CurrentVersion.targets` folds `NoWarn` into `MSBuildWarningsAsMessages` and `WarningsAsErrors` into `MSBuildWarningsAsErrors`. Either `MSBuild`-prefixed property can be set directly instead, alongside `MSBuildWarningsNotAsErrors` to exempt a code from a blanket `MSBuildTreatWarningsAsErrors`.
 
 Errors cannot be suppressed. Each one names an item the task refuses to guess at, and continuing would publicize something other than what was asked for.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,35 +1,51 @@
 # Diagnostics
 
-Every error and warning the `PublicizeAssemblies` task raises carries a `PUBxxxx` code, so it can be found, filtered, and suppressed the way MSBuild's own diagnostics are. Codes are defined in `src/Publicizer/DiagnosticCode.cs`; `DiagnosticCodeTests` fails if a code there is missing from the table below.
+Every error and warning Publicizer raises carries a `PUBxxxx` code, so it can be found, filtered, and suppressed the way MSBuild's own diagnostics are. Codes are defined in `src/Publicizer/DiagnosticCode.cs`; `DiagnosticCodeTests` fails if that file and the table below disagree in either direction.
 
-A code names a **failure class**, not a message. The malformed-`Type` spellings all report `PUB0005` and differ only in text, so suppressing one suppresses them all. Codes are permanent: a retired diagnostic keeps its number rather than freeing it for reuse, and a new one takes the next free number regardless of where it fits thematically.
+A code names a **failure class**, not a message. The malformed-`Type` spellings all report `PUB1005` and differ only in text, so suppressing one suppresses them all.
+
+## Numbering
+
+Codes are banded by what raises them, not by theme — a theme moves as features do, an emitter does not. Within a band, a new code takes the next free number.
+
+| Band | Raised by |
+|---|---|
+| `PUB1xxx` | Parsing and validating `Publicize`/`DoNotPublicize` items |
+| `PUB2xxx` | Task execution and I/O |
+| `PUB3xxx` | The outcome of publicizing an assembly |
+| `PUB4xxx` | The MSBuild targets, rather than the task |
+| `PUB9xxx` | Reserved for a future analyzer or BuildCheck surface |
+
+A code is permanent **once it has appeared in a release**: a retired diagnostic keeps its number rather than freeing it for reuse, because consumers key `NoWarn` on it. Before its first release a code is still soft, and may be renumbered or dropped outright.
+
+## Codes
 
 | Code | Severity | Raised when |
 |---|---|---|
-| `PUB0001` | Error | An item mixes the colon form with `Namespace`/`Type` metadata. |
-| `PUB0002` | Error | An item sets a member-level qualifier the structured syntax reserves but does not implement yet (`Field`, `Method`, `Property`, `Event`, `Accessor`, `Parameters`). |
-| `PUB0003` | Error | An item sets `IncludeSubNamespaces` or `IncludeTypeContents`. A scope's descent is unconditional today and cannot be narrowed. |
-| `PUB0004` | Error | A scope's `Namespace` is not a plain dotted namespace name. |
-| `PUB0005` | Error | A scope's `Type` is malformed — a backtick or `+`, unbalanced braces, an empty name segment, or an empty or nested type argument list. |
-| `PUB0006` | Error | A scope sets `MemberPattern`, which only the bare-assembly item accepts. |
-| `PUB0007` | Error | A `DoNotPublicize` scope sets `IncludeVirtualMembers` or `IncludeCompilerGeneratedMembers`. A deny scope has no sweep for a filter to apply to. |
-| `PUB0008` | Error | A scope nested inside another leaves a filter the enclosing scope sets unset. Whether an inner scope inherits its enclosing scope's filters or the assembly's is not decided yet, so it must be set explicitly. |
-| `PUB0009` | Warning | An assembly is `DoNotPublicize`d as a whole while `Publicize` scopes name part of it. The scopes are more specific and win. |
-| `PUB0010` | Warning | An assembly was marked for publicization, but nothing in it was publicized. |
-| `PUB0011` | Error | `OutputDirectory` is not a usable directory path. |
-| `PUB0012` | Error | The log file named by `PublicizerLogFilePath` could not be created. |
+| `PUB1001` | Error | An item mixes the colon form with `Namespace`/`Type` metadata. |
+| `PUB1002` | Error | An item sets a member-level qualifier the structured syntax reserves but does not implement yet (`Field`, `Method`, `Property`, `Event`, `Accessor`, `Parameters`). |
+| `PUB1003` | Error | An item sets `IncludeSubNamespaces` or `IncludeTypeContents`. A scope's descent is unconditional today and cannot be narrowed. |
+| `PUB1004` | Error | A scope's `Namespace` is not a plain dotted namespace name. |
+| `PUB1005` | Error | A scope's `Type` is malformed — a backtick or `+`, unbalanced braces, an empty name segment, or an empty or nested type argument list. |
+| `PUB1006` | Error | A scope sets `MemberPattern`, which only the bare-assembly item accepts. |
+| `PUB1007` | Error | A `DoNotPublicize` scope sets `IncludeVirtualMembers` or `IncludeCompilerGeneratedMembers`. A deny scope has no sweep for a filter to apply to. |
+| `PUB2001` | Error | `OutputDirectory` is not a usable directory path. |
+| `PUB2002` | Error | The log file named by `PublicizerLogFilePath` could not be created. |
+| `PUB3001` | Warning | An assembly is `DoNotPublicize`d as a whole while `Publicize` scopes name part of it. The scopes are more specific and win. |
+| `PUB3002` | Warning | An assembly was marked for publicization, but nothing in it was publicized. |
+| `PUB4001` | Warning | `PublicizerRuntimeStrategies` enables neither `Unsafe` nor `IgnoresAccessChecksTo`, so publicized members compile but fail their visibility check at run time. Suppress it if the referenced assembly is already public at run time. |
 
 ## Suppressing a warning
 
-In an SDK-style project, the SDK feeds `NoWarn` and `WarningsAsErrors` through to MSBuild's own warning routing, so a `PUBxxxx` warning is silenced or promoted the same way a compiler warning is:
+`NoWarn` and `WarningsAsErrors` route `PUBxxxx` warnings the same way they route compiler warnings:
 
 ```xml
 <PropertyGroup>
-  <NoWarn>$(NoWarn);PUB0010</NoWarn>
-  <WarningsAsErrors>$(WarningsAsErrors);PUB0009</WarningsAsErrors>
+  <NoWarn>$(NoWarn);PUB3002</NoWarn>
+  <WarningsAsErrors>$(WarningsAsErrors);PUB3001</WarningsAsErrors>
 </PropertyGroup>
 ```
 
-Outside the SDK those two properties are the compiler's alone and do nothing here. Use MSBuild's equivalents instead: `MSBuildWarningsAsMessages` and `MSBuildWarningsAsErrors`.
+This is not an SDK feature. `Microsoft.Common.CurrentVersion.targets` folds `NoWarn` into `MSBuildWarningsAsMessages` and `WarningsAsErrors` into `MSBuildWarningsAsErrors`, so it works in non-SDK projects too. Those `MSBuild`-prefixed properties can also be set directly, alongside `MSBuildWarningsNotAsErrors` to exempt a code from a blanket `MSBuildTreatWarningsAsErrors`.
 
 Errors cannot be suppressed. Each one names an item the task refuses to guess at, and continuing would publicize something other than what was asked for.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,35 @@
+# Diagnostics
+
+Every error and warning the `PublicizeAssemblies` task raises carries a `PUBxxxx` code, so it can be found, filtered, and suppressed the way MSBuild's own diagnostics are. Codes are defined in `src/Publicizer/DiagnosticCode.cs`; `DiagnosticCodeTests` fails if a code there is missing from the table below.
+
+A code names a **failure class**, not a message. The malformed-`Type` spellings all report `PUB0005` and differ only in text, so suppressing one suppresses them all. Codes are permanent: a retired diagnostic keeps its number rather than freeing it for reuse, and a new one takes the next free number regardless of where it fits thematically.
+
+| Code | Severity | Raised when |
+|---|---|---|
+| `PUB0001` | Error | An item mixes the colon form with `Namespace`/`Type` metadata. |
+| `PUB0002` | Error | An item sets a member-level qualifier the structured syntax reserves but does not implement yet (`Field`, `Method`, `Property`, `Event`, `Accessor`, `Parameters`). |
+| `PUB0003` | Error | An item sets `IncludeSubNamespaces` or `IncludeTypeContents`. A scope's descent is unconditional today and cannot be narrowed. |
+| `PUB0004` | Error | A scope's `Namespace` is not a plain dotted namespace name. |
+| `PUB0005` | Error | A scope's `Type` is malformed — a backtick or `+`, unbalanced braces, an empty name segment, or an empty or nested type argument list. |
+| `PUB0006` | Error | A scope sets `MemberPattern`, which only the bare-assembly item accepts. |
+| `PUB0007` | Error | A `DoNotPublicize` scope sets `IncludeVirtualMembers` or `IncludeCompilerGeneratedMembers`. A deny scope has no sweep for a filter to apply to. |
+| `PUB0008` | Error | A scope nested inside another leaves a filter the enclosing scope sets unset. Whether an inner scope inherits its enclosing scope's filters or the assembly's is not decided yet, so it must be set explicitly. |
+| `PUB0009` | Warning | An assembly is `DoNotPublicize`d as a whole while `Publicize` scopes name part of it. The scopes are more specific and win. |
+| `PUB0010` | Warning | An assembly was marked for publicization, but nothing in it was publicized. |
+| `PUB0011` | Error | `OutputDirectory` is not a usable directory path. |
+| `PUB0012` | Error | The log file named by `PublicizerLogFilePath` could not be created. |
+
+## Suppressing a warning
+
+In an SDK-style project, the SDK feeds `NoWarn` and `WarningsAsErrors` through to MSBuild's own warning routing, so a `PUBxxxx` warning is silenced or promoted the same way a compiler warning is:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);PUB0010</NoWarn>
+  <WarningsAsErrors>$(WarningsAsErrors);PUB0009</WarningsAsErrors>
+</PropertyGroup>
+```
+
+Outside the SDK those two properties are the compiler's alone and do nothing here. Use MSBuild's equivalents instead: `MSBuildWarningsAsMessages` and `MSBuildWarningsAsErrors`.
+
+Errors cannot be suppressed. Each one names an item the task refuses to guess at, and continuing would publicize something other than what was asked for.

--- a/src/Publicizer.E2ETests/DiagnosticSuppressionTests.cs
+++ b/src/Publicizer.E2ETests/DiagnosticSuppressionTests.cs
@@ -1,0 +1,92 @@
+using NUnit.Framework;
+
+namespace Publicizer.E2ETests;
+
+// The PUBxxxx codes exist so a consumer can route the warning like any other MSBuild
+// warning. Unit tests prove the code reaches the build engine; only a real build proves
+// NoWarn and WarningsAsErrors actually route on it.
+internal static class DiagnosticSuppressionTests
+{
+    // Nothing private to publicize, so the task raises PUB3002.
+    private const string AllPublicCode = """
+        namespace PublicNamespace;
+        public class PublicClass
+        {
+            public string PublicField = "foo";
+        }
+        """;
+
+    private static TestProject ConsumerOf(TestProject library) => TestProject.App("System.Console.Write(new PublicNamespace.PublicClass().PublicField);")
+        .Referencing(library)
+        .ConsumingPublicizer()
+        .Item("Publicize", "PublicAssembly:PublicNamespace.PublicClass.NoSuchMember");
+
+    [Test]
+    public static void Warning_IsReportedWithItsCode()
+    {
+        using TestProject library = TestProject.Library("PublicAssembly", AllPublicCode).BuildOrFail();
+        using TestProject app = ConsumerOf(library);
+
+        ProcessResult result = app.Build();
+
+        Assert.That(result.ExitCode, Is.Zero, result.Output);
+        Assert.That(result.Output, Does.Contain("PUB3002"), result.Output);
+    }
+
+    [Test]
+    public static void NoWarn_SuppressesTheWarning()
+    {
+        using TestProject library = TestProject.Library("PublicAssembly", AllPublicCode).BuildOrFail();
+        using TestProject app = ConsumerOf(library).Property("NoWarn", "$(NoWarn);PUB3002");
+
+        ProcessResult result = app.Build();
+
+        Assert.That(result.ExitCode, Is.Zero, result.Output);
+        Assert.That(result.Output, Does.Not.Contain("PUB3002"), result.Output);
+    }
+
+    [Test]
+    public static void WarningsAsErrors_PromotesTheWarningAndFailsTheBuild()
+    {
+        using TestProject library = TestProject.Library("PublicAssembly", AllPublicCode).BuildOrFail();
+        using TestProject app = ConsumerOf(library).Property("WarningsAsErrors", "$(WarningsAsErrors);PUB3002");
+
+        ProcessResult result = app.Build();
+
+        Assert.That(result.ExitCode, Is.Not.Zero, result.Output);
+        Assert.That(result.Output, Does.Contain("PUB3002"), result.Output);
+    }
+
+    // PUB4001 used to be an error, which failed a build that a consumer whose target assembly is
+    // already public at run time had every right to make.
+    [Test]
+    public static void NoRuntimeStrategy_WarnsWithoutFailingTheBuild()
+    {
+        using TestProject library = TestProject.Library("PrivateAssembly", PublicizerTests.PrivateClassIn("PrivateNamespace")).BuildOrFail();
+        using TestProject app = TestProject.App("System.Console.Write(1);")
+            .Referencing(library)
+            .ConsumingPublicizer()
+            .Item("Publicize", "PrivateAssembly")
+            .Property("PublicizerRuntimeStrategies", "");
+
+        ProcessResult result = app.Build();
+
+        Assert.That(result.ExitCode, Is.Zero, result.Output);
+        Assert.That(result.Output, Does.Contain("PUB4001"), result.Output);
+    }
+
+    // The strategies live in the same target as the publicization, so an unconditioned diagnostic
+    // would fire on any project that merely references the package.
+    [Test]
+    public static void NoRuntimeStrategy_IsSilentWhenNothingWasPublicized()
+    {
+        using TestProject app = TestProject.App("System.Console.Write(1);")
+            .ConsumingPublicizer()
+            .Property("PublicizerRuntimeStrategies", "");
+
+        ProcessResult result = app.Build();
+
+        Assert.That(result.ExitCode, Is.Zero, result.Output);
+        Assert.That(result.Output, Does.Not.Contain("PUB4001"), result.Output);
+    }
+}

--- a/src/Publicizer.Tests/DiagnosticCodeTests.cs
+++ b/src/Publicizer.Tests/DiagnosticCodeTests.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+
+namespace Publicizer.Tests;
+
+/// <summary>
+/// Guards the diagnostic codes themselves: their shape, their uniqueness, and that each one is
+/// documented. The individual diagnostics are covered where their behavior is — mostly
+/// <see cref="StructuredTargetTests"/>.
+/// </summary>
+internal static class DiagnosticCodeTests
+{
+    private static IEnumerable<(string Name, string Code)> Codes() =>
+        typeof(DiagnosticCode)
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.IsLiteral)
+            .Select(field => (field.Name, (string)field.GetRawConstantValue()!));
+
+    /// <summary>Resolves docs/diagnostics.md from this source file, so it does not depend on the test's working directory.</summary>
+    private static string DocumentationPath([CallerFilePath] string testFilePath = "") =>
+        Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testFilePath)!, "..", "..", "docs", "diagnostics.md"));
+
+    [Test]
+    public static void Codes_AreWellFormedAndUnique()
+    {
+        (string Name, string Code)[] codes = [.. Codes()];
+
+        Assert.That(codes, Is.Not.Empty);
+        Assert.That(codes.Select(entry => entry.Code), Is.Unique);
+
+        foreach ((string name, string code) in codes)
+        {
+            Assert.That(code, Has.Length.EqualTo(7), $"{name} = '{code}' is not a PUBxxxx code");
+            Assert.That(code, Does.StartWith("PUB"), $"{name} = '{code}' is not a PUBxxxx code");
+            Assert.That(code[3..], Is.All.InRange('0', '9'), $"{name} = '{code}' is not a PUBxxxx code");
+        }
+    }
+
+    [Test]
+    public static void Codes_AreDocumented()
+    {
+        // The table is the user-facing contract; a code that never reaches it cannot be looked up.
+        string documentation = File.ReadAllText(DocumentationPath());
+
+        foreach ((string name, string code) in Codes())
+        {
+            Assert.That(documentation, Does.Contain($"`{code}`"), $"{name} = '{code}' is missing from docs/diagnostics.md");
+        }
+    }
+
+    [Test]
+    public static void LoggedDiagnostics_ReachMSBuildWithTheirCode()
+    {
+        // The task logger has overloads that silently drop the code, so assert on what the build
+        // engine actually receives rather than on the logger call.
+        var engine = new FakeBuildEngine();
+        using var logger = new Logger(new TaskLoggingHelper(engine, "PublicizeAssemblies"), Stream.Null);
+
+        logger.Error(DiagnosticCode.InvalidType, "an error");
+        logger.Warning(DiagnosticCode.NothingPublicized, "a warning");
+
+        string[] expectedErrorCodes = [DiagnosticCode.InvalidType];
+        string[] expectedWarningCodes = [DiagnosticCode.NothingPublicized];
+        Assert.That(engine.ErrorCodes, Is.EqualTo(expectedErrorCodes));
+        Assert.That(engine.WarningCodes, Is.EqualTo(expectedWarningCodes));
+    }
+
+    [Test]
+    public static void MessagesWithBraces_AreNotTreatedAsFormatStrings()
+    {
+        // Several 'Type' diagnostics quote a spelling like 'MyType{T1,T2}', which MSBuild would try
+        // to format if any format arguments were passed.
+        var engine = new FakeBuildEngine();
+        using var logger = new Logger(new TaskLoggingHelper(engine, "PublicizeAssemblies"), Stream.Null);
+
+        logger.Error(DiagnosticCode.InvalidType, "write 'MyType{T1,T2}'");
+
+        string[] expected = ["write 'MyType{T1,T2}'"];
+        Assert.That(engine.Errors, Is.EqualTo(expected));
+    }
+}

--- a/src/Publicizer.Tests/DiagnosticCodeTests.cs
+++ b/src/Publicizer.Tests/DiagnosticCodeTests.cs
@@ -46,7 +46,50 @@ internal static class DiagnosticCodeTests
 
         foreach ((string name, string code) in Codes())
         {
-            Assert.That(documentation, Does.Contain($"`{code}`"), $"{name} = '{code}' is missing from docs/diagnostics.md");
+            Assert.That(documentation, Does.Contain($"| `{code}` |"), $"{name} = '{code}' has no row in docs/diagnostics.md");
+        }
+    }
+
+    [Test]
+    public static void DocumentedCodes_StillExist()
+    {
+        // The other direction: a removed code leaves a row behind that nothing raises, which reads
+        // as a diagnostic a user can expect and never gets.
+        string[] declared = [.. Codes().Select(entry => entry.Code)];
+        // Only rows naming a concrete code: the band table above them spells its rows 'PUB1xxx'.
+        string[] documented = [.. File.ReadAllLines(DocumentationPath())
+            .Where(line => line.StartsWith("| `PUB", StringComparison.Ordinal))
+            .Select(line => line.Split('`')[1])
+            .Where(code => code[3..].All(char.IsAsciiDigit))];
+
+        Assert.That(documented, Is.Not.Empty);
+
+        foreach (string code in documented)
+        {
+            Assert.That(declared, Does.Contain(code), $"docs/diagnostics.md documents '{code}', which no longer exists in DiagnosticCode");
+        }
+    }
+
+    [Test]
+    public static void TargetsRaisedCode_MatchesItsConstant()
+    {
+        // PUB4001 is raised by the targets, so the constant is the only thing tying it to this
+        // table — nothing would otherwise notice the two drifting apart.
+        string targets = File.ReadAllText(Path.Combine(Path.GetDirectoryName(DocumentationPath())!, "..", "src", "Publicizer", "Krafs.Publicizer.targets"));
+
+        Assert.That(targets, Does.Contain($"""Code="{DiagnosticCode.NoRuntimeStrategy}" """.TrimEnd()));
+    }
+
+    [Test]
+    public static void Codes_AreBanded()
+    {
+        // An unbanded code would sit in whichever band it happens to collide with, and the band is
+        // the thing that keeps room to insert later.
+        string[] bands = ["PUB1", "PUB2", "PUB3", "PUB4", "PUB9"];
+
+        foreach ((string name, string code) in Codes())
+        {
+            Assert.That(bands, Has.Some.EqualTo(code[..4]), $"{name} = '{code}' is outside every documented band");
         }
     }
 

--- a/src/Publicizer.Tests/ExecuteTests.cs
+++ b/src/Publicizer.Tests/ExecuteTests.cs
@@ -93,6 +93,7 @@ internal static class ExecuteTests
         Assert.That(task.ReferencePathsToAdd, Is.Empty);
         Assert.That(task.ReferencePathsToDelete, Is.Empty);
         Assert.That(engine.Warnings, Has.Some.Contains("no members were publicized"));
+        Assert.That(engine.WarningCodes, Has.Some.EqualTo(DiagnosticCode.NothingPublicized));
     }
 
     [Test]

--- a/src/Publicizer.Tests/FakeBuildEngine.cs
+++ b/src/Publicizer.Tests/FakeBuildEngine.cs
@@ -12,9 +12,21 @@ internal sealed class FakeBuildEngine : IBuildEngine
     internal List<string> Errors { get; } = [];
     internal List<string> Warnings { get; } = [];
     internal List<string> Messages { get; } = [];
+    internal List<string> ErrorCodes { get; } = [];
+    internal List<string> WarningCodes { get; } = [];
 
-    public void LogErrorEvent(BuildErrorEventArgs e) => Errors.Add(e.Message ?? string.Empty);
-    public void LogWarningEvent(BuildWarningEventArgs e) => Warnings.Add(e.Message ?? string.Empty);
+    public void LogErrorEvent(BuildErrorEventArgs e)
+    {
+        Errors.Add(e.Message ?? string.Empty);
+        ErrorCodes.Add(e.Code ?? string.Empty);
+    }
+
+    public void LogWarningEvent(BuildWarningEventArgs e)
+    {
+        Warnings.Add(e.Message ?? string.Empty);
+        WarningCodes.Add(e.Code ?? string.Empty);
+    }
+
     public void LogMessageEvent(BuildMessageEventArgs e) => Messages.Add(e.Message ?? string.Empty);
     public void LogCustomEvent(CustomBuildEventArgs e) { }
 

--- a/src/Publicizer.Tests/NullTaskLogger.cs
+++ b/src/Publicizer.Tests/NullTaskLogger.cs
@@ -5,8 +5,8 @@ internal sealed class NullTaskLogger : ITaskLogger
 {
     internal static NullTaskLogger Instance { get; } = new();
 
-    public void Error(string message) { }
-    public void Warning(string message) { }
+    public void Error(string code, string message) { }
+    public void Warning(string code, string message) { }
     public void Info(string message) { }
     public void Verbose(string message) { }
 }

--- a/src/Publicizer.Tests/RecordingTaskLogger.cs
+++ b/src/Publicizer.Tests/RecordingTaskLogger.cs
@@ -1,13 +1,28 @@
 namespace Publicizer.Tests;
 
-/// <summary>Captures logged errors and warnings so parser diagnostics can be asserted on.</summary>
+/// <summary>
+/// Captures logged errors and warnings so parser diagnostics can be asserted on. Entries are
+/// recorded as <c>"PUB0001: message"</c>, so a test can assert on the code, the text, or both.
+/// </summary>
 internal sealed class RecordingTaskLogger : ITaskLogger
 {
     internal List<string> Errors { get; } = [];
     internal List<string> Warnings { get; } = [];
+    internal List<string> ErrorCodes { get; } = [];
+    internal List<string> WarningCodes { get; } = [];
 
-    public void Error(string message) => Errors.Add(message);
-    public void Warning(string message) => Warnings.Add(message);
+    public void Error(string code, string message)
+    {
+        Errors.Add($"{code}: {message}");
+        ErrorCodes.Add(code);
+    }
+
+    public void Warning(string code, string message)
+    {
+        Warnings.Add($"{code}: {message}");
+        WarningCodes.Add(code);
+    }
+
     public void Info(string message) { }
     public void Verbose(string message) { }
 }

--- a/src/Publicizer.Tests/StructuredTargetTests.cs
+++ b/src/Publicizer.Tests/StructuredTargetTests.cs
@@ -41,17 +41,6 @@ internal static class StructuredTargetTests
         return string.Join(" | ", logger.Errors);
     }
 
-    private static string ErrorForAll(params ITaskItem[] publicizes)
-    {
-        var logger = new RecordingTaskLogger();
-
-        bool valid = PublicizeAssemblies.TryGetPublicizerAssemblyContexts(publicizes, [], logger, out _);
-
-        Assert.That(valid, Is.False, "expected the items to be rejected");
-        Assert.That(logger.Errors, Is.Not.Empty);
-        return string.Join(" | ", logger.Errors);
-    }
-
     private static TypePlan? Plan(PublicizerAssemblyContext context, string typeReflectionName, string typeNamespace) =>
         AssemblyPlan.Compile(context).ForType(typeReflectionName, typeNamespace);
 
@@ -160,32 +149,6 @@ internal static class StructuredTargetTests
 
         TypePlan elsewhere = Plan(context, "B.Type", "B")!;
         Assert.That(elsewhere.IncludeVirtualMembers, Is.False);
-    }
-
-    /// <summary>
-    /// An inner scope could inherit the outer scope's filter or the assembly's, and the two readings
-    /// differ only in which members end up public — so picking one now and changing it later would
-    /// silently rewrite working builds. The ambiguous item is refused instead. See
-    /// <c>PublicizeAssemblies.ScopeFilterInheritanceIsDecidable</c>.
-    /// </summary>
-    [Test]
-    public static void InnerScope_LeavingAnEnclosingScopesFilterUnset_IsRejected()
-    {
-        string namespaceInNamespace = ErrorForAll(
-            Item("Asm", "Namespace", "A", "IncludeVirtualMembers", "false"),
-            Item("Asm", "Namespace", "A.B", "IncludeCompilerGeneratedMembers", "false"));
-        Assert.That(namespaceInNamespace, Does.Contain("IncludeVirtualMembers").And.Contains("not decided yet"));
-        Assert.That(namespaceInNamespace, Does.Contain("Namespace=\"A.B\"").And.Contains("Namespace=\"A\""));
-
-        // A type scope inside a namespace scope, and a nested type scope inside its encloser.
-        Assert.That(
-            ErrorForAll(Item("Asm", "Type", "Outer", "IncludeCompilerGeneratedMembers", "false"), Item("Asm", "Type", "Outer.Inner")),
-            Does.Contain("IncludeCompilerGeneratedMembers"));
-
-        // The authored spelling is quoted back, not the lowered reflection name.
-        Assert.That(
-            ErrorForAll(Item("Asm", "Type", "Outer{T}", "IncludeVirtualMembers", "false"), Item("Asm", "Type", "Outer{T}.Inner")),
-            Does.Contain("Type=\"Outer{T}.Inner\"").And.Contains("Type=\"Outer{T}\""));
     }
 
     [Test]

--- a/src/Publicizer.Tests/StructuredTargetTests.cs
+++ b/src/Publicizer.Tests/StructuredTargetTests.cs
@@ -419,5 +419,5 @@ internal static class StructuredTargetTests
 
     [Test]
     public static void DoNotPublicizeErrors_NameTheItemKind() =>
-        Assert.That(ErrorFor(Item("Asm", "Type", "Holder`1"), deny: true), Does.StartWith("DoNotPublicize item"));
+        Assert.That(ErrorFor(Item("Asm", "Type", "Holder`1"), deny: true), Does.StartWith($"{DiagnosticCode.InvalidType}: DoNotPublicize item"));
 }

--- a/src/Publicizer/DiagnosticCode.cs
+++ b/src/Publicizer/DiagnosticCode.cs
@@ -1,50 +1,67 @@
 namespace Publicizer;
 
 /// <summary>
-/// Codes carried by every error and warning the task raises, so they can be suppressed, filtered and
+/// Codes carried by every error and warning Publicizer raises, so they can be suppressed, filtered and
 /// searched. One code per failure class, not per message: the malformed-<c>Type</c> spellings, for
 /// instance, share a code and differ only in message text.
 /// </summary>
 /// <remarks>
-/// Codes are permanent. A retired diagnostic keeps its number rather than freeing it for reuse, and a
-/// new one takes the next free number regardless of where it fits thematically. Keep
-/// docs/diagnostics.md in sync.
+/// <para>
+/// Numbers are banded by what raises them, not by theme — a theme moves as features do, an emitter
+/// does not. Within a band a new code takes the next free number.
+/// </para>
+/// <list type="bullet">
+/// <item><c>PUB1xxx</c> — parsing and validating <c>Publicize</c>/<c>DoNotPublicize</c> items.</item>
+/// <item><c>PUB2xxx</c> — task execution and I/O.</item>
+/// <item><c>PUB3xxx</c> — the outcome of publicizing an assembly.</item>
+/// <item><c>PUB4xxx</c> — raised from the MSBuild targets rather than the task.</item>
+/// <item><c>PUB9xxx</c> — reserved for a future analyzer or BuildCheck surface.</item>
+/// </list>
+/// <para>
+/// A code is permanent once it has appeared in a release: a retired diagnostic keeps its number
+/// rather than freeing it for reuse, because consumers key <c>NoWarn</c> on it. Before a code's first
+/// release it is still soft, and may be renumbered or dropped outright. Keep docs/diagnostics.md in
+/// sync either way.
+/// </para>
 /// </remarks>
 internal static class DiagnosticCode
 {
     /// <summary>An item mixes the colon form with structured metadata.</summary>
-    internal const string FormsMixed = "PUB0001";
+    internal const string FormsMixed = "PUB1001";
 
     /// <summary>An item sets a member-level qualifier the structured syntax reserves but does not implement yet.</summary>
-    internal const string UnsupportedMemberMetadata = "PUB0002";
+    internal const string UnsupportedMemberMetadata = "PUB1002";
 
     /// <summary>An item sets a qualifier that would narrow a scope's descent, which is unconditional today.</summary>
-    internal const string UnsupportedDescentMetadata = "PUB0003";
+    internal const string UnsupportedDescentMetadata = "PUB1003";
 
     /// <summary>A scope's <c>Namespace</c> is not a plain dotted namespace name.</summary>
-    internal const string InvalidNamespace = "PUB0004";
+    internal const string InvalidNamespace = "PUB1004";
 
     /// <summary>A scope's <c>Type</c> is malformed.</summary>
-    internal const string InvalidType = "PUB0005";
+    internal const string InvalidType = "PUB1005";
 
     /// <summary>A scope sets <c>MemberPattern</c>, which only the bare assembly item accepts.</summary>
-    internal const string MemberPatternOnScope = "PUB0006";
+    internal const string MemberPatternOnScope = "PUB1006";
 
     /// <summary>A <c>DoNotPublicize</c> scope sets a sweep filter, which it has no sweep to apply to.</summary>
-    internal const string FilterOnDenyScope = "PUB0007";
-
-    /// <summary>A scope inside another scope leaves a filter the enclosing scope sets unset, and inheritance is undecided.</summary>
-    internal const string UndecidedScopeInheritance = "PUB0008";
-
-    /// <summary>An assembly is denied as a whole while <c>Publicize</c> scopes name part of it.</summary>
-    internal const string AssemblyDenyOverriddenByScopes = "PUB0009";
-
-    /// <summary>An assembly was marked for publicization, but nothing in it was publicized.</summary>
-    internal const string NothingPublicized = "PUB0010";
+    internal const string FilterOnDenyScope = "PUB1007";
 
     /// <summary><c>OutputDirectory</c> is not a usable directory path.</summary>
-    internal const string InvalidOutputDirectory = "PUB0011";
+    internal const string InvalidOutputDirectory = "PUB2001";
 
     /// <summary>The log file named by <c>PublicizerLogFilePath</c> could not be created.</summary>
-    internal const string LogFileNotCreated = "PUB0012";
+    internal const string LogFileNotCreated = "PUB2002";
+
+    /// <summary>An assembly is denied as a whole while <c>Publicize</c> scopes name part of it.</summary>
+    internal const string AssemblyDenyOverriddenByScopes = "PUB3001";
+
+    /// <summary>An assembly was marked for publicization, but nothing in it was publicized.</summary>
+    internal const string NothingPublicized = "PUB3002";
+
+    /// <summary>
+    /// No runtime access strategy is enabled, so the publicized members compile but fail their
+    /// visibility check at run time. Raised from Krafs.Publicizer.targets, which repeats the literal.
+    /// </summary>
+    internal const string NoRuntimeStrategy = "PUB4001";
 }

--- a/src/Publicizer/DiagnosticCode.cs
+++ b/src/Publicizer/DiagnosticCode.cs
@@ -1,0 +1,50 @@
+namespace Publicizer;
+
+/// <summary>
+/// Codes carried by every error and warning the task raises, so they can be suppressed, filtered and
+/// searched. One code per failure class, not per message: the malformed-<c>Type</c> spellings, for
+/// instance, share a code and differ only in message text.
+/// </summary>
+/// <remarks>
+/// Codes are permanent. A retired diagnostic keeps its number rather than freeing it for reuse, and a
+/// new one takes the next free number regardless of where it fits thematically. Keep
+/// docs/diagnostics.md in sync.
+/// </remarks>
+internal static class DiagnosticCode
+{
+    /// <summary>An item mixes the colon form with structured metadata.</summary>
+    internal const string FormsMixed = "PUB0001";
+
+    /// <summary>An item sets a member-level qualifier the structured syntax reserves but does not implement yet.</summary>
+    internal const string UnsupportedMemberMetadata = "PUB0002";
+
+    /// <summary>An item sets a qualifier that would narrow a scope's descent, which is unconditional today.</summary>
+    internal const string UnsupportedDescentMetadata = "PUB0003";
+
+    /// <summary>A scope's <c>Namespace</c> is not a plain dotted namespace name.</summary>
+    internal const string InvalidNamespace = "PUB0004";
+
+    /// <summary>A scope's <c>Type</c> is malformed.</summary>
+    internal const string InvalidType = "PUB0005";
+
+    /// <summary>A scope sets <c>MemberPattern</c>, which only the bare assembly item accepts.</summary>
+    internal const string MemberPatternOnScope = "PUB0006";
+
+    /// <summary>A <c>DoNotPublicize</c> scope sets a sweep filter, which it has no sweep to apply to.</summary>
+    internal const string FilterOnDenyScope = "PUB0007";
+
+    /// <summary>A scope inside another scope leaves a filter the enclosing scope sets unset, and inheritance is undecided.</summary>
+    internal const string UndecidedScopeInheritance = "PUB0008";
+
+    /// <summary>An assembly is denied as a whole while <c>Publicize</c> scopes name part of it.</summary>
+    internal const string AssemblyDenyOverriddenByScopes = "PUB0009";
+
+    /// <summary>An assembly was marked for publicization, but nothing in it was publicized.</summary>
+    internal const string NothingPublicized = "PUB0010";
+
+    /// <summary><c>OutputDirectory</c> is not a usable directory path.</summary>
+    internal const string InvalidOutputDirectory = "PUB0011";
+
+    /// <summary>The log file named by <c>PublicizerLogFilePath</c> could not be created.</summary>
+    internal const string LogFileNotCreated = "PUB0012";
+}

--- a/src/Publicizer/ITaskLogger.cs
+++ b/src/Publicizer/ITaskLogger.cs
@@ -1,6 +1,10 @@
 namespace Publicizer;
 
-public interface ITaskLogger
+/// <remarks>
+/// Internal: the package ships the task assembly under build/, never lib/, so nothing outside this
+/// assembly can reference this type. Keeping it public would make its shape API by accident.
+/// </remarks>
+internal interface ITaskLogger
 {
     /// <param name="code">A <see cref="DiagnosticCode"/> value, so the diagnostic can be suppressed and filtered.</param>
     /// <param name="message">The diagnostic text.</param>

--- a/src/Publicizer/ITaskLogger.cs
+++ b/src/Publicizer/ITaskLogger.cs
@@ -1,9 +1,15 @@
-﻿namespace Publicizer;
+namespace Publicizer;
 
 public interface ITaskLogger
 {
-    void Error(string message);
-    void Warning(string message);
+    /// <param name="code">A <see cref="DiagnosticCode"/> value, so the diagnostic can be suppressed and filtered.</param>
+    /// <param name="message">The diagnostic text.</param>
+    void Error(string code, string message);
+
+    /// <param name="code">A <see cref="DiagnosticCode"/> value, so the diagnostic can be suppressed and filtered.</param>
+    /// <param name="message">The diagnostic text.</param>
+    void Warning(string code, string message);
+
     void Info(string message);
     void Verbose(string message);
 }

--- a/src/Publicizer/Krafs.Publicizer.props
+++ b/src/Publicizer/Krafs.Publicizer.props
@@ -16,6 +16,12 @@
     </Compile>
   </ItemGroup>
 
+  <!--
+    The sweep filter defaults are load-bearing beyond their values: because every Publicize item
+    carries them, a scope nested inside another scope always has a concrete value and never has to
+    inherit one. That is what keeps the scope-to-scope filter inheritance rule an open question
+    rather than something already pinned by shipped behaviour. Dropping the defaults here reopens it.
+  -->
   <ItemDefinitionGroup>
     <Publicize Visible="false" IncludeCompilerGeneratedMembers="true" IncludeVirtualMembers="true" />
     <DoNotPublicize Visible="false" />

--- a/src/Publicizer/Krafs.Publicizer.targets
+++ b/src/Publicizer/Krafs.Publicizer.targets
@@ -28,8 +28,16 @@
       <_UseIactStrategy>$([System.Text.RegularExpressions.Regex]::IsMatch($(PublicizerRuntimeStrategies), $(_IactPattern), RegexOptions.IgnoreCase))</_UseIactStrategy>
     </PropertyGroup>
 
-    <Error Text="'PublicizerRuntimeStrategies' must contain one or both of 'Unsafe' and 'IgnoresAccessChecksTo'. Defaults to both ('Unsafe;IgnoresAccessChecksTo') if unspecified."
-           Condition="!$(_UseUnsafeStrategy) AND !$(_UseIactStrategy)"/>
+    <!--
+      A warning, not an error: with neither strategy the publicized members still compile, and a
+      consumer whose target assembly is already public at run time genuinely needs neither. That
+      case suppresses PUB4001; a misspelled strategy still gets caught rather than surfacing later
+      as a MethodAccessException. Only raised once a reference was actually swapped, so merely
+      referencing the package with an empty value stays silent.
+    -->
+    <Warning Code="PUB4001"
+             Text="'PublicizerRuntimeStrategies' contains neither 'Unsafe' nor 'IgnoresAccessChecksTo', so publicized members will fail their visibility check at run time. Defaults to both ('Unsafe;IgnoresAccessChecksTo') if unspecified."
+             Condition="!$(_UseUnsafeStrategy) AND !$(_UseIactStrategy) AND '@(_ReferencePathsToAdd)' != ''"/>
 
     <ItemGroup Condition="$(_UseIactStrategy)" >
       <AssemblyAttribute Include="System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute">

--- a/src/Publicizer/Logger.cs
+++ b/src/Publicizer/Logger.cs
@@ -41,16 +41,18 @@ internal sealed class Logger : ITaskLogger, IDisposable
         this.scope = $" [{scope}]";
     }
 
-    public void Error(string message)
+    public void Error(string code, string message)
     {
-        taskLogger.LogError(message);
-        Write("ERR", message);
+        // The overload carrying a code is the only one MSBuild lets a consumer key on, and the
+        // messages hold literal braces, so no format arguments are passed.
+        taskLogger.LogError(null, code, null, null, 0, 0, 0, 0, message);
+        Write("ERR", $"{code}: {message}");
     }
 
-    public void Warning(string message)
+    public void Warning(string code, string message)
     {
-        taskLogger.LogWarning(message);
-        Write("WRN", message);
+        taskLogger.LogWarning(null, code, null, null, 0, 0, 0, 0, message);
+        Write("WRN", $"{code}: {message}");
     }
 
     public void Info(string message)

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -188,11 +188,6 @@ public sealed class PublicizeAssemblies : Task
 
         if (valid)
         {
-            valid = ScopeFilterInheritanceIsDecidable(contexts, logger);
-        }
-
-        if (valid)
-        {
             WarnOnScopesOverridingAnAssemblyDeny(contexts, logger);
         }
 
@@ -221,55 +216,6 @@ public sealed class PublicizeAssemblies : Task
         }
 
         return modified;
-    }
-
-    /// <summary>
-    /// Rejects an inner scope that leaves a sweep filter unset which an enclosing scope sets.
-    /// <para>
-    /// Whether such a scope should inherit that filter from the scope enclosing it or from the
-    /// assembly is a real design question, and both answers are defensible. It is left open rather
-    /// than settled here because settling it wrong is unrecoverable: the two readings differ only in
-    /// which members end up public, so changing the answer later would silently rewrite assemblies
-    /// that build fine today. Refusing the item keeps both doors open at the cost of one attribute.
-    /// </para>
-    /// <para>
-    /// Assembly-to-scope inheritance is not affected — that one is decided, documented and pinned.
-    /// Neither is a <c>DoNotPublicize</c> scope, which publicizes nothing and so cannot be swayed by
-    /// a filter either way.
-    /// </para>
-    /// </summary>
-    private static bool ScopeFilterInheritanceIsDecidable(Dictionary<string, PublicizerAssemblyContext> contexts, ITaskLogger logger)
-    {
-        bool decidable = true;
-
-        foreach (PublicizerAssemblyContext context in contexts.Values)
-        {
-            foreach (PublicizeScope inner in context.Scopes)
-            {
-                if (inner.Deny)
-                {
-                    continue;
-                }
-
-                foreach (PublicizeScope outer in context.Scopes)
-                {
-                    // Equally specific scopes resolve to a single winner, so neither inherits from the
-                    // other and there is nothing to be ambiguous about.
-                    if (inner.Specificity.CompareTo(outer.Specificity) <= 0 || !outer.Contains(inner))
-                    {
-                        continue;
-                    }
-
-                    foreach (string filter in outer.FiltersLeftUnsetOn(inner))
-                    {
-                        logger.Error(DiagnosticCode.UndecidedScopeInheritance, $"Publicize scope '{inner.Display}' on '{context.AssemblyName}' sits inside '{outer.Display}', which sets '{filter}'. Set '{filter}' explicitly on the inner scope: whether an inner scope inherits an enclosing scope's filters or the assembly's is not decided yet.");
-                        decidable = false;
-                    }
-                }
-            }
-        }
-
-        return decidable;
     }
 
     /// <summary>

--- a/src/Publicizer/PublicizeAssemblies.cs
+++ b/src/Publicizer/PublicizeAssemblies.cs
@@ -43,7 +43,7 @@ public sealed class PublicizeAssemblies : Task
             }
             catch (Exception e)
             {
-                Log.LogError($"Error creating Publicizer log file: {e.Message}");
+                Log.LogError(null, DiagnosticCode.LogFileNotCreated, null, null, 0, 0, 0, 0, $"Error creating Publicizer log file: {e.Message}");
             }
         }
 
@@ -72,7 +72,7 @@ public sealed class PublicizeAssemblies : Task
         }
         catch (Exception e)
         {
-            logger.Error($"{nameof(OutputDirectory)} '{OutputDirectory}' is not a valid directory path: {e.Message}");
+            logger.Error(DiagnosticCode.InvalidOutputDirectory, $"{nameof(OutputDirectory)} '{OutputDirectory}' is not a valid directory path: {e.Message}");
             return false;
         }
 
@@ -115,7 +115,7 @@ public sealed class PublicizeAssemblies : Task
                 bool isAssemblyModified = PublicizeAssembly(module, assemblyContext, scopedLogger);
                 if (!isAssemblyModified)
                 {
-                    scopedLogger.Warning("Assembly is marked for publicization, but no members were publicized");
+                    scopedLogger.Warning(DiagnosticCode.NothingPublicized, "Assembly is marked for publicization, but no members were publicized");
                     continue;
                 }
 
@@ -262,7 +262,7 @@ public sealed class PublicizeAssemblies : Task
 
                     foreach (string filter in outer.FiltersLeftUnsetOn(inner))
                     {
-                        logger.Error($"Publicize scope '{inner.Display}' on '{context.AssemblyName}' sits inside '{outer.Display}', which sets '{filter}'. Set '{filter}' explicitly on the inner scope: whether an inner scope inherits an enclosing scope's filters or the assembly's is not decided yet.");
+                        logger.Error(DiagnosticCode.UndecidedScopeInheritance, $"Publicize scope '{inner.Display}' on '{context.AssemblyName}' sits inside '{outer.Display}', which sets '{filter}'. Set '{filter}' explicitly on the inner scope: whether an inner scope inherits an enclosing scope's filters or the assembly's is not decided yet.");
                         decidable = false;
                     }
                 }
@@ -291,7 +291,7 @@ public sealed class PublicizeAssemblies : Task
             int overriding = context.Scopes.Count(scope => !scope.Deny);
             if (overriding > 0)
             {
-                logger.Warning($"'{context.AssemblyName}' is marked DoNotPublicize as a whole, but {overriding} Publicize scope(s) name part of it. The scopes are more specific, so they win. Remove the DoNotPublicize item if that is what you meant.");
+                logger.Warning(DiagnosticCode.AssemblyDenyOverriddenByScopes, $"'{context.AssemblyName}' is marked DoNotPublicize as a whole, but {overriding} Publicize scope(s) name part of it. The scopes are more specific, so they win. Remove the DoNotPublicize item if that is what you meant.");
             }
         }
     }

--- a/src/Publicizer/PublicizeItemParser.cs
+++ b/src/Publicizer/PublicizeItemParser.cs
@@ -68,7 +68,7 @@ internal sealed class PublicizeItemParser
 
         if (colon >= 0 && isStructured)
         {
-            return Fail($"the '{itemName} Include=\"Assembly:Member\"' form cannot be combined with 'Namespace' or 'Type' metadata. Use one form or the other.");
+            return Fail(DiagnosticCode.FormsMixed, $"the '{itemName} Include=\"Assembly:Member\"' form cannot be combined with 'Namespace' or 'Type' metadata. Use one form or the other.");
         }
 
         // Reserved qualifiers are rejected rather than ignored, so a target written against the
@@ -78,7 +78,7 @@ internal sealed class PublicizeItemParser
         {
             if (Metadata(name) is not null)
             {
-                Error($"'{name}' metadata is not supported yet. Target members with the '{itemName} Include=\"Assembly:Namespace.Type.Member\"' form.");
+                Error(DiagnosticCode.UnsupportedMemberMetadata, $"'{name}' metadata is not supported yet. Target members with the '{itemName} Include=\"Assembly:Namespace.Type.Member\"' form.");
                 valid = false;
             }
         }
@@ -87,7 +87,7 @@ internal sealed class PublicizeItemParser
         {
             if (Metadata(name) is not null)
             {
-                Error($"'{name}' metadata is not supported yet. A '{itemName}' scope reaches everything beneath the node it names, and that cannot be narrowed yet.");
+                Error(DiagnosticCode.UnsupportedDescentMetadata, $"'{name}' metadata is not supported yet. A '{itemName}' scope reaches everything beneath the node it names, and that cannot be narrowed yet.");
                 valid = false;
             }
         }
@@ -137,13 +137,13 @@ internal sealed class PublicizeItemParser
 
         if (namespaceName.IndexOfAny(['`', '{', '}', '+']) >= 0)
         {
-            return Fail($"'Namespace' must be a plain dotted namespace name, but was '{namespaceName}'.");
+            return Fail(DiagnosticCode.InvalidNamespace, $"'Namespace' must be a plain dotted namespace name, but was '{namespaceName}'.");
         }
 
         // Same segment rule 'Type' is held to: a dot separates two names, so neither side may be empty.
         if (namespaceName.Length > 0 && Array.Exists(namespaceName.Split('.'), segment => segment.Length == 0))
         {
-            return Fail($"'Namespace' has an empty name segment: '{namespaceName}'.");
+            return Fail(DiagnosticCode.InvalidNamespace, $"'Namespace' has an empty name segment: '{namespaceName}'.");
         }
 
         // Rejected on every scope, not just a deny one. The regex is matched against dnlib's
@@ -152,7 +152,7 @@ internal sealed class PublicizeItemParser
         // and the assembly-level pattern is already slated to be re-anchored or dropped.
         if (Metadata("MemberPattern") is not null)
         {
-            return Fail($"'MemberPattern' is not supported on a scope. Put it on the bare '{itemName} Include=\"Assembly\"' item, which still applies inside every scope, or name the members with the '{itemName} Include=\"Assembly:Namespace.Type.Member\"' form.");
+            return Fail(DiagnosticCode.MemberPatternOnScope, $"'MemberPattern' is not supported on a scope. Put it on the bare '{itemName} Include=\"Assembly\"' item, which still applies inside every scope, or name the members with the '{itemName} Include=\"Assembly:Namespace.Type.Member\"' form.");
         }
 
         if (deny && HasFiltersOnDenyScope())
@@ -199,7 +199,7 @@ internal sealed class PublicizeItemParser
         {
             if (Metadata(name) is not null)
             {
-                Error($"'{name}' has no meaning on a DoNotPublicize scope, which excludes members rather than sweeping them. Put it on the Publicize item whose sweep you want to filter.");
+                Error(DiagnosticCode.FilterOnDenyScope, $"'{name}' has no meaning on a DoNotPublicize scope, which excludes members rather than sweeping them. Put it on the Publicize item whose sweep you want to filter.");
                 found = true;
             }
         }
@@ -218,12 +218,12 @@ internal sealed class PublicizeItemParser
 
         if (typeValue.IndexOf('`') >= 0)
         {
-            return Fail($"'Type' must not contain a backtick. Write generic arity as 'MyType{{T1,T2}}' rather than 'MyType`2'.");
+            return Fail(DiagnosticCode.InvalidType, $"'Type' must not contain a backtick. Write generic arity as 'MyType{{T1,T2}}' rather than 'MyType`2'.");
         }
 
         if (typeValue.IndexOf('+') >= 0)
         {
-            return Fail($"'Type' must not contain '+'. Separate a nested type from its enclosing type with '.', as in 'Outer.Inner'.");
+            return Fail(DiagnosticCode.InvalidType, $"'Type' must not contain '+'. Separate a nested type from its enclosing type with '.', as in 'Outer.Inner'.");
         }
 
         if (!TrySplitNestingChain(typeValue, out List<string> segments))
@@ -276,7 +276,7 @@ internal sealed class PublicizeItemParser
                 depth--;
                 if (depth < 0)
                 {
-                    return Fail($"'Type' has unbalanced braces: '{typeValue}'.");
+                    return Fail(DiagnosticCode.InvalidType, $"'Type' has unbalanced braces: '{typeValue}'.");
                 }
             }
             else if (c == '.' && depth == 0)
@@ -288,7 +288,7 @@ internal sealed class PublicizeItemParser
 
         if (depth != 0)
         {
-            return Fail($"'Type' has unbalanced braces: '{typeValue}'.");
+            return Fail(DiagnosticCode.InvalidType, $"'Type' has unbalanced braces: '{typeValue}'.");
         }
 
         segments.Add(typeValue.Substring(segmentStart));
@@ -304,7 +304,7 @@ internal sealed class PublicizeItemParser
 
         if (name.Length == 0)
         {
-            return Fail($"'Type' has an empty name segment: '{typeValue}'.");
+            return Fail(DiagnosticCode.InvalidType, $"'Type' has an empty name segment: '{typeValue}'.");
         }
 
         if (brace < 0)
@@ -315,20 +315,20 @@ internal sealed class PublicizeItemParser
 
         if (segment[segment.Length - 1] != '}')
         {
-            return Fail($"'Type' segment '{segment}' must end its type argument list with '}}'.");
+            return Fail(DiagnosticCode.InvalidType, $"'Type' segment '{segment}' must end its type argument list with '}}'.");
         }
 
         string arguments = segment.Substring(brace + 1, segment.Length - brace - 2);
         if (arguments.Trim().Length == 0)
         {
-            return Fail($"'Type' segment '{segment}' has an empty type argument list. Drop the braces for a non-generic type.");
+            return Fail(DiagnosticCode.InvalidType, $"'Type' segment '{segment}' has an empty type argument list. Drop the braces for a non-generic type.");
         }
 
         // A nested argument list would make the commas ambiguous — 'Holder{Dictionary{K,V}}' has one
         // argument, not two — and nothing reads the names yet anyway, so refuse rather than guess.
         if (arguments.IndexOf('{') >= 0)
         {
-            return Fail($"'Type' segment '{segment}' has a nested type argument list, which is not supported. Only the number of type arguments is read, so write 'MyType{{T1,T2}}'.");
+            return Fail(DiagnosticCode.InvalidType, $"'Type' segment '{segment}' has a nested type argument list, which is not supported. Only the number of type arguments is read, so write 'MyType{{T1,T2}}'.");
         }
 
         // Only the count is read today, but the names are reserved for 'Parameters'. Accepting a
@@ -336,7 +336,7 @@ internal sealed class PublicizeItemParser
         string[] typeArguments = arguments.Split(',');
         if (Array.Exists(typeArguments, argument => argument.Trim().Length == 0))
         {
-            return Fail($"'Type' segment '{segment}' has an empty type argument name. Name every argument, as in 'MyType{{T1,T2}}'.");
+            return Fail(DiagnosticCode.InvalidType, $"'Type' segment '{segment}' has an empty type argument name. Name every argument, as in 'MyType{{T1,T2}}'.");
         }
 
         segmentName = name + "`" + typeArguments.Length;
@@ -354,12 +354,12 @@ internal sealed class PublicizeItemParser
         return namespaceName.Length == 0 ? $"Type=\"{typeValue}\"" : $"Namespace=\"{namespaceName}\" Type=\"{typeValue}\"";
     }
 
-    private void Error(string message) => logger.Error($"{itemName} item '{spec}': {message}");
+    private void Error(string code, string message) => logger.Error(code, $"{itemName} item '{spec}': {message}");
 
     /// <summary>Reports one rejection and returns <see langword="false"/>, so call sites can return it directly.</summary>
-    private bool Fail(string message)
+    private bool Fail(string code, string message)
     {
-        Error(message);
+        Error(code, message);
         return false;
     }
 

--- a/src/Publicizer/PublicizeScope.cs
+++ b/src/Publicizer/PublicizeScope.cs
@@ -72,23 +72,6 @@ internal sealed class PublicizeScope
         : inner.TypeReflectionName is not null && IsStrictlyUnder(inner.TypeReflectionName, TypeReflectionName, '+');
 
     /// <summary>
-    /// The names of the sweep filters this scope sets and <paramref name="inner"/> leaves unset —
-    /// exactly the ones whose value inside <paramref name="inner"/> depends on an inheritance rule.
-    /// </summary>
-    internal IEnumerable<string> FiltersLeftUnsetOn(PublicizeScope inner)
-    {
-        if (IncludeVirtualMembers is not null && inner.IncludeVirtualMembers is null)
-        {
-            yield return nameof(IncludeVirtualMembers);
-        }
-
-        if (IncludeCompilerGeneratedMembers is not null && inner.IncludeCompilerGeneratedMembers is null)
-        {
-            yield return nameof(IncludeCompilerGeneratedMembers);
-        }
-    }
-
-    /// <summary>
     /// Whether <paramref name="candidate"/> is <paramref name="prefix"/> itself, or a name nested
     /// under it — where <paramref name="separator"/> is what joins a parent name to a child.
     /// </summary>


### PR DESCRIPTION
Every task error and warning now carries a `PUBxxxx` code, so users can suppress, promote and search them, and so the structured syntax's parse errors do not ship codeless.

- Codes name a failure class, not a message — all malformed-`Type` spellings report `PUB0005`.
- `docs/diagnostics.md` holds the table; a test fails if a code is missing from it.
- Verified against real MSBuild: in SDK projects `NoWarn`/`WarningsAsErrors` route these codes; outside the SDK they do not, and the docs point at `MSBuildWarningsAsMessages`/`MSBuildWarningsAsErrors` instead.

`ITaskLogger` is public, and its `Error`/`Warning` signatures changed.